### PR TITLE
Add valid georeference tag to osm map.

### DIFF
--- a/example_opt_carma/maps/vector_map.osm
+++ b/example_opt_carma/maps/vector_map.osm
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <osm version="0.6" generator="lanelet2">
+  <geoReference>+proj=tmerc +lat_0=39.46636844371259 +lon_0=-76.16919523566943 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs</geoReference>
   <node id="1338" visible="true" version="1" lat="0" lon="0" />
   <node id="1339" visible="true" version="1" lat="0.00000898315" lon="0" />
   <node id="1340" visible="true" version="1" lat="0.00001796631" lon="0" />


### PR DESCRIPTION
This PR adds a georeference tag to the example osm map.
This is in support of https://github.com/usdot-fhwa-stol/carma-platform/issues/664
