### PR TITLE
Update dev config to point to develop image

### DIFF
--- a/development/carma.config.js
+++ b/development/carma.config.js
@@ -41,7 +41,7 @@ CarmaJS.registerNamespace("CarmaJS.Config");
 
 CarmaJS.Config = (function () {
         //Private variables
-        var ip = 'localhost'; //'192.168.88.10'; 192.168.32.146;
+        var ip = '127.0.0.1'; //'192.168.88.10'; 192.168.32.146;
 
         //Private methods
         //Creating functions to prevent access by reference to private variables

--- a/development/docker-compose-background.yml
+++ b/development/docker-compose-background.yml
@@ -17,9 +17,9 @@ version: '2'
 
 services:
   web-ui:
-    image: usdotfhwastol/carma-web-ui:CARMASystem_3.3.0
+    image: usdotfhwastoldev/carma-web-ui:develop
     network_mode: host
-    container_name: web-ui
+    container_name: carma-web-ui
     environment:
       - ROS_IP=127.0.0.1
     volumes_from: 

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -17,7 +17,7 @@ version: '2'
 
 services:
   roscore:
-    image: usdotfhwastol/carma-base:3.7.0
+    image: usdotfhwastoldev/carma-base:develop
     network_mode: host
     container_name: roscore
     volumes_from: 
@@ -30,7 +30,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: platform
     volumes_from: 
@@ -47,7 +47,7 @@ services:
     command: wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch
 
   mock-lightbar-driver:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: carma-mock-lightbar-driver
     volumes_from: 
@@ -61,7 +61,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=lightbar'
 
   mock-can-driver:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: carma-mock-can-driver
     volumes_from: 
@@ -74,7 +74,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=can'
 
   mock-comms-driver:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: carma-mock-comms-driver
     volumes_from: 
@@ -87,7 +87,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=comms'
 
   mock-controller-driver:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: carma-srx-controller-driver
     volumes_from: 
@@ -100,7 +100,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=controller'
 
   mock-radar-driver:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: carma-mock-radar-driver
     volumes_from: 
@@ -113,7 +113,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=radar'
 
   mock-gnss-driver:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: carma-mock-gnss-driver
     volumes_from: 
@@ -126,7 +126,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=gnss'
 
   mock-imu-driver:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: carma-mock-imu-driver
     volumes_from: 
@@ -139,7 +139,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=imu'
 
   mock-lidar-driver:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: carma-mock-lidar-driver
     volumes_from: 
@@ -152,7 +152,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=lidar'
 
   mock-camera-driver:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: carma-mock-camera-driver
     volumes_from: 
@@ -165,7 +165,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=camera'
     
   mock-roadway-sensor-driver:
-    image: usdotfhwastol/carma-platform:latest
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: carma-mock-roadway-sensor-driver
     volumes_from: 


### PR DESCRIPTION
Currently the development configs are pointing to usdotfhwastol instead of usdotfhwastolDEV. 

Also "latest" is not available when someone has not built any of the images locally and only pulled from DockerHub. Updated to point to develop images. 

Confirmed this configuration updates are starting locally with carma start all. 

No need for Issue # as this is only a config change. 