### PR TITLE
Fix 786

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/drivers.launch
+++ b/chrysler_pacifica_ehybrid_s_2019/drivers.launch
@@ -47,7 +47,7 @@ If not using simulated drivers they are activated if the respective mock argumen
 
 
   <!-- Specific Drivers -->
-  <arg name="drivers" default="dsrc_driver ssc_interface_wrapper novatel_gps_driver velodyne_lidar_driver_wrapper lightbar_driver"
+  <arg name="drivers" default="dsrc_driver ssc_interface_wrapper novatel_gps_driver velodyne_lidar_driver_wrapper lightbar_driver avt_vimba_camera"
     doc="Desired real drivers to launch specified by package name. Mock drivers will take precedence"/>
 
   <arg name="dsrc_driver"                   value="$(eval ('dsrc_driver' in arg('drivers').split()) and not arg('mock_comms'))"/>
@@ -96,7 +96,7 @@ If not using simulated drivers they are activated if the respective mock argumen
     <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
  	<arg name="frame_id" default="left_optical"/>
 	<arg name="trig_timestamp_topic" default=""/>
-	<arg name="show_debug_prints" default="true"/>
+	<arg name="show_debug_prints" default="false"/>
   </include>
   
   <!-- AVT Vimba Camera Right Driver Node 

--- a/ford_fusion_sehybrid_2019/drivers.launch
+++ b/ford_fusion_sehybrid_2019/drivers.launch
@@ -45,7 +45,7 @@ If not using simulated drivers they are activated if the respective mock argumen
   <arg name="mock_lightbar"       value="$(eval 'lightbar' in arg('mock_drivers').split())"/>
 
   <!-- Specific Drivers -->
-  <arg name="drivers" default="dsrc_driver ssc_interface_wrapper novatel_gps_driver velodyne_lidar_driver_wrapper lightbar_driver"
+  <arg name="drivers" default="dsrc_driver ssc_interface_wrapper novatel_gps_driver velodyne_lidar_driver_wrapper lightbar_driver avt_vimba_camera"
     doc="Desired real drivers to launch specified by package name. Mock drivers will take precedence"/>
 
   <arg name="dsrc_driver"                   value="$(eval ('dsrc_driver' in arg('drivers').split()) and not arg('mock_comms'))"/>
@@ -92,7 +92,7 @@ If not using simulated drivers they are activated if the respective mock argumen
     <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
  	<arg name="frame_id" default="left_optical"/>
 	<arg name="trig_timestamp_topic" default=""/>
-	<arg name="show_debug_prints" default="true"/>
+	<arg name="show_debug_prints" default="false"/>
   </include>
 
   <!-- AVT Vimba Camera Right Driver Node 

--- a/freightliner_cascadia_2012/drivers.launch
+++ b/freightliner_cascadia_2012/drivers.launch
@@ -46,7 +46,7 @@ If not using simulated drivers they are activated if the respective mock argumen
   <arg name="mock_lightbar" 	    value="$(eval 'lightbar' in arg('mock_drivers').split())"/>
 
   <!-- Specific Drivers -->
-  <arg name="drivers" default="dsrc_driver ssc_interface_wrapper novatel_gps_driver velodyne_lidar_driver_wrapper lidar_lite_trailer_angle_driver lightbar_driver"
+  <arg name="drivers" default="dsrc_driver ssc_interface_wrapper novatel_gps_driver velodyne_lidar_driver_wrapper lidar_lite_trailer_angle_driver lightbar_driver avt_vimba_camera"
     doc="Desired real drivers to launch specified by package name. Mock drivers will take precedence"/>
 
   <arg name="dsrc_driver"                     value="$(eval ('dsrc_driver' in arg('drivers').split()) and not arg('mock_comms'))"/>
@@ -55,6 +55,7 @@ If not using simulated drivers they are activated if the respective mock argumen
   <arg name="velodyne_lidar_driver_wrapper"   value="$(eval ('velodyne_lidar_driver_wrapper' in arg('drivers').split()) and not arg('mock_lidar'))"/>
   <arg name="lidar_lite_trailer_angle_driver" value="$(eval ('lidar_lite_trailer_angle_driver' in arg('drivers').split()) and not arg('mock_trailer_angle'))"/>
   <arg name="lightbar_driver"                 value="$(eval ('lightbar_driver' in arg('drivers').split()) and not arg('mock_lightbar'))"/>
+  <arg name="avt_vimba_camera"               value="$(eval ('avt_vimba_camera' in arg('drivers').split()) and not arg('mock_camera'))"/>
 
   <!-- DSRC OBU Driver Node -->
   <include if="$(arg dsrc_driver)" file="$(find dsrc_driver)/launch/dsrc_node.launch"/>
@@ -118,15 +119,17 @@ If not using simulated drivers they are activated if the respective mock argumen
   </include>
   
   <!-- AVT Vimba Camera Left Driver Node -->
- <remap from="camera/camera_info" to="dummy_camera_info"/>
-  <include if="$(arg avt_vimba_camera)" file="$(find avt_vimba_camera)/launch/mono_camera.launch">
-	<arg name="guid" default=""/>
- 	<arg name="ip" default="192.168.30.10"/>
-    <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
- 	<arg name="frame_id" default="left_optical"/>
-	<arg name="trig_timestamp_topic" default=""/>
-	<arg name="show_debug_prints" default="true"/>
-   </include>
+  <group>
+    <remap from="camera/camera_info" to="dummy_camera_info"/>
+    <include if="$(arg avt_vimba_camera)" file="$(find avt_vimba_camera)/launch/mono_camera.launch">
+      <arg name="guid" default=""/>
+      <arg name="ip" default="192.168.30.10"/>
+      <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
+      <arg name="frame_id" default="left_optical"/>
+      <arg name="trig_timestamp_topic" default=""/>
+      <arg name="show_debug_prints" default="false"/>
+    </include>
+  </group>
   
   <!-- AVT Vimba Camera Right Driver Node 
     <include if="$(arg avt_vimba_camera)" ns="camera_right" file="$(find avt_vimba_camera)/launch/mono_camera.launch">

--- a/lexus_rx_450h_2019/drivers.launch
+++ b/lexus_rx_450h_2019/drivers.launch
@@ -45,7 +45,7 @@ If not using simulated drivers they are activated if the respective mock argumen
   <arg name="mock_lightbar" 	    value="$(eval 'lightbar' in arg('mock_drivers').split())"/>
 
   <!-- Specific Drivers -->
-  <arg name="drivers" default="dsrc_driver ssc_interface_wrapper novatel_gps_driver velodyne_lidar_driver_wrapper lightbar_driver"
+  <arg name="drivers" default="dsrc_driver ssc_interface_wrapper novatel_gps_driver velodyne_lidar_driver_wrapper lightbar_driver avt_vimba_camera"
     doc="Desired real drivers to launch specified by package name. Mock drivers will take precedence"/>
 
   <arg name="dsrc_driver"                   value="$(eval ('dsrc_driver' in arg('drivers').split()) and not arg('mock_comms'))"/>
@@ -96,7 +96,7 @@ If not using simulated drivers they are activated if the respective mock argumen
   <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
  	<arg name="frame_id" default="left_optical"/>
 	<arg name="trig_timestamp_topic" default=""/>
-	<arg name="show_debug_prints" default="true"/>
+	<arg name="show_debug_prints" default="false"/>
   </include>
   
   <!-- AVT Vimba Camera Right Driver Node 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/786 by adding the expected avt_vimba_camera argument to the truck launch file. Also corrects some non-breaking issues with the other 4 drivers.launch files. 
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/786
## Motivation and Context
Functional truck config
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Silver truck
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.