### PR TITLE
Add arg "non_simulation_mode"

### DIFF
--- a/carla_integration/carma_docker.launch
+++ b/carla_integration/carma_docker.launch
@@ -39,6 +39,9 @@
   <!-- Launch without drivers as those will be launched as docker containers-->
   <arg name="launch_drivers" default="false"/>
 
+  <!-- Launch the CARMA-CARLA simulation -->
+  <arg name="non_simulation_mode" default="false"/>
+
   <!-- Rosbag Flag -->
   <arg name="use_rosbag" default="true"/>
 

--- a/carla_integration/carma_docker.launch
+++ b/carla_integration/carma_docker.launch
@@ -40,7 +40,7 @@
   <arg name="launch_drivers" default="false"/>
 
   <!-- Launch the CARMA-CARLA simulation -->
-  <arg name="non_simulation_mode" default="false"/>
+  <arg name="simulation_mode" default="true"/>
 
   <!-- Rosbag Flag -->
   <arg name="use_rosbag" default="true"/>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Add an argument to support CARMA simulation mode, which will config nodes launching in CARMA platform.
<!--- Describe your changes in detail -->
Add an argument "non_simulation_mode" in the carla_simulation configuration. The value will be false if the simulation is launched.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested with CARMA simulation launching and standard mock drivers launching.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.