### PR TITLE
Add socket_ip/port arguments in drivers.launch

### DIFF
--- a/carla_integration/drivers.launch
+++ b/carla_integration/drivers.launch
@@ -25,6 +25,8 @@ If not using simulated drivers they are activated if the respective mock argumen
 
 <launch>
   <arg name='role_name' default='ego_vehicle'/>
+  <arg name="socket_ip" default="127.0.0.1" />
+  <arg name="socket_port" default="8080" />
 
   <!-- handling global prameters -->
   <remap from="~vehicle_wheel_base" to="/vehicle_wheel_base"/> 
@@ -38,6 +40,9 @@ If not using simulated drivers they are activated if the respective mock argumen
     <arg name='role_name' value='$(arg role_name)'/>
   </include>
   
-  <include file="$(find carla_carma)/launch/carma_comm.launch"/>
+  <include file="$(find carla_carma)/launch/carma_comm.launch">
+    <arg name="socket_ip" value='$(arg socket_ip)'/>
+    <arg name="socket_port" value='$(arg socket_port)'/>
+  </include>
 
 </launch>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Make socket ip and port as configurable arguments for socket communication with CARLA Interface.
<!--- Describe your changes in detail -->
Add arguments socket ip and port in driver.launch file.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Make socket ip and port as configurable arguments for socket communication with CARLA Interface.
## How Has This Been Tested?
Tested in CEE environment.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.