### PR TITLE
Fix config speed limit

### DIFF
--- a/carla_integration/VehicleConfigParams.yaml
+++ b/carla_integration/VehicleConfigParams.yaml
@@ -65,3 +65,6 @@ required_drivers:
 lidar_gps_drivers:
   - /hardware_interface/mock_lidar
   - /hardware_interface/mock_gnss
+
+# Parameter to enable configurable speed limit
+config_speed_limit: 45.0

--- a/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
+++ b/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
@@ -73,4 +73,4 @@ lidar_gps_drivers:
   - /hardware_interface/novatel_gps_nodelet_wrapper
 
 # Parameter to enable configurable speed limit
-config_speed_limit: 0.0
+config_speed_limit: 45.0

--- a/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
+++ b/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
@@ -73,5 +73,5 @@ lidar_gps_drivers:
   - /hardware_interface/novatel_gps_nodelet_wrapper
 
 
-  # Parameter to enable configurable speed limit
-  config_speed_limit: 0.0
+# Parameter to enable configurable speed limit
+config_speed_limit: 45.0

--- a/freightliner_cascadia_2012/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012/VehicleConfigParams.yaml
@@ -77,7 +77,7 @@ lidar_gps_drivers:
   - /hardware_interface/novatel_gps_nodelet_wrapper
 
 # Parameter to enable configurable speed limit
-config_speed_limit: 0.0
+config_speed_limit: 45.0
 
 
 

--- a/lexus_rx_450h_2019/VehicleConfigParams.yaml
+++ b/lexus_rx_450h_2019/VehicleConfigParams.yaml
@@ -73,4 +73,4 @@ lidar_gps_drivers:
   - /hardware_interface/novatel_gps_nodelet_wrapper
 
 # Parameter to enable configurable speed limit
-config_speed_limit: 0.0
+config_speed_limit: 45.0


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/899 by fixing the identation on the ford fusion speed limit value. Adding the value to the carla config and setting all values to 45.0 mph
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
See above
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Usable vehicle configs for all configurations
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fix tested on ford fusion
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.