### PR TITLE
set default speed limit

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/carma.config.js
+++ b/chrysler_pacifica_ehybrid_s_2019/carma.config.js
@@ -42,15 +42,18 @@ CarmaJS.registerNamespace("CarmaJS.Config");
 CarmaJS.Config = (function () {
         //Private variables
         var ip = '192.168.88.10';
-
+        var speed_limit = 30; //Default Speed Limit
         //Private methods
         //Creating functions to prevent access by reference to private variables
         var getIP = function() {
             return ip;
         };
-
+        var getSPEEDLIMIT = function() {
+            return speed_limit;
+        };
         //Public API
         return {
-            getIP: getIP
+            getIP: getIP,
+            getSPEEDLIMIT: getSPEEDLIMIT
         };
 })();

--- a/development/carma.config.js
+++ b/development/carma.config.js
@@ -45,7 +45,7 @@ CarmaJS.Config = (function () {
         var refresh_interval = 30; //30 seconds 
         var ros_connect_wait = 5000; //5 miliseconds to wait for platform to launch and ros to connect.
         var ros_connect_retry = 24; //# of times to wait. Total 2 minutes
-
+        var speed_limit = 30; //Default Speed Limit
         //Private methods
         //Creating functions to prevent access by reference to private variables
         var getIP = function() {
@@ -60,12 +60,15 @@ CarmaJS.Config = (function () {
         var getRosConnectionRetry = function() {
             return ros_connect_retry;
         };
-
+        var getSPEEDLIMIT = function() {
+            return speed_limit;
+        };
         //Public API
         return {
             getIP: getIP,
             getRefreshInterval: getRefreshInterval,
             getRosConnectionWaitTime:getRosConnectionWaitTime,
-            getRosConnectionRetry:getRosConnectionRetry
+            getRosConnectionRetry:getRosConnectionRetry,
+            getSPEEDLIMIT: getSPEEDLIMIT
         };
 })();

--- a/ford_fusion_sehybrid_2019/carma.config.js
+++ b/ford_fusion_sehybrid_2019/carma.config.js
@@ -42,15 +42,18 @@ CarmaJS.registerNamespace("CarmaJS.Config");
 CarmaJS.Config = (function () {
         //Private variables
         var ip = '192.168.88.10';
-
+        var speed_limit = 30; //Default Speed Limit
         //Private methods
         //Creating functions to prevent access by reference to private variables
         var getIP = function() {
             return ip;
         };
-
+        var getSPEEDLIMIT = function() {
+            return speed_limit;
+        };
         //Public API
         return {
-            getIP: getIP
+            getIP: getIP,
+            getSPEEDLIMIT: getSPEEDLIMIT
         };
 })();

--- a/freightliner_cascadia_2012_dot_10002/carma.config.js
+++ b/freightliner_cascadia_2012_dot_10002/carma.config.js
@@ -42,15 +42,18 @@ CarmaJS.registerNamespace("CarmaJS.Config");
 CarmaJS.Config = (function () {
         //Private variables
         var ip = '192.168.88.10';
-
+        var speed_limit = 30; //Default Speed Limit
         //Private methods
         //Creating functions to prevent access by reference to private variables
         var getIP = function() {
             return ip;
         };
-
+        var getSPEEDLIMIT = function() {
+            return speed_limit;
+        };
         //Public API
         return {
-            getIP: getIP
+            getIP: getIP,
+            getSPEEDLIMIT: getSPEEDLIMIT
         };
 })();

--- a/freightliner_cascadia_2012_dot_10003/carma.config.js
+++ b/freightliner_cascadia_2012_dot_10003/carma.config.js
@@ -42,15 +42,18 @@ CarmaJS.registerNamespace("CarmaJS.Config");
 CarmaJS.Config = (function () {
         //Private variables
         var ip = '192.168.88.10';
-
+        var speed_limit = 30; //Default Speed Limit
         //Private methods
         //Creating functions to prevent access by reference to private variables
         var getIP = function() {
             return ip;
         };
-
+        var getSPEEDLIMIT = function() {
+            return speed_limit;
+        };
         //Public API
         return {
-            getIP: getIP
+            getIP: getIP,
+            getSPEEDLIMIT: getSPEEDLIMIT
         };
 })();

--- a/freightliner_cascadia_2012_dot_10004/carma.config.js
+++ b/freightliner_cascadia_2012_dot_10004/carma.config.js
@@ -42,15 +42,18 @@ CarmaJS.registerNamespace("CarmaJS.Config");
 CarmaJS.Config = (function () {
         //Private variables
         var ip = '192.168.88.10';
-
+        var speed_limit = 30; //Default Speed Limit
         //Private methods
         //Creating functions to prevent access by reference to private variables
         var getIP = function() {
             return ip;
         };
-
+        var getSPEEDLIMIT = function() {
+            return speed_limit;
+        };
         //Public API
         return {
-            getIP: getIP
+            getIP: getIP,
+            getSPEEDLIMIT: getSPEEDLIMIT
         };
 })();

--- a/freightliner_cascadia_2012_dot_80550/carma.config.js
+++ b/freightliner_cascadia_2012_dot_80550/carma.config.js
@@ -42,15 +42,18 @@ CarmaJS.registerNamespace("CarmaJS.Config");
 CarmaJS.Config = (function () {
         //Private variables
         var ip = '192.168.88.10';
-
+        var speed_limit = 30; //Default Speed Limit
         //Private methods
         //Creating functions to prevent access by reference to private variables
         var getIP = function() {
             return ip;
         };
-
+        var getSPEEDLIMIT = function() {
+            return speed_limit;
+        };
         //Public API
         return {
-            getIP: getIP
+            getIP: getIP,
+            getSPEEDLIMIT: getSPEEDLIMIT
         };
 })();

--- a/lexus_rx_450h_2019/carma.config.js
+++ b/lexus_rx_450h_2019/carma.config.js
@@ -42,15 +42,18 @@ CarmaJS.registerNamespace("CarmaJS.Config");
 CarmaJS.Config = (function () {
         //Private variables
         var ip = '192.168.0.100';
-
+        var speed_limit = 30; //Default Speed Limit
         //Private methods
         //Creating functions to prevent access by reference to private variables
         var getIP = function() {
             return ip;
         };
-
+        var getSPEEDLIMIT = function() {
+            return speed_limit;
+        };
         //Public API
         return {
-            getIP: getIP
+            getIP: getIP,
+            getSPEEDLIMIT: getSPEEDLIMIT
         };
 })();


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Verify that UI can display the default speed limit value the same as the value specified in the carma config carma.config.js
## Description

<!--- Describe your changes in detail -->
Add default speed limit to carma config file, this allows to overwrite default speed limit displayed on UI
## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/916
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
ACE demo
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.