### PR TITLE
avt vimba camera calibration fix

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
+++ b/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
@@ -103,6 +103,7 @@ excluded_default_topics:
   - (.*)/received_messages
   - (.*)/sent_messages
   - (.*)/scan
+  - (.*)/compressed(.*)
 
 exclude_lidar: false
 excluded_lidar_topics:

--- a/chrysler_pacifica_ehybrid_s_2019/drivers.launch
+++ b/chrysler_pacifica_ehybrid_s_2019/drivers.launch
@@ -91,7 +91,7 @@ If not using simulated drivers they are activated if the respective mock argumen
   <include if="$(arg avt_vimba_camera)" file="$(find avt_vimba_camera)/launch/mono_camera.launch">
 	<arg name="guid" default=""/>
  	<arg name="ip" default="192.168.30.10"/>
-    <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
+    <arg name="camera_info_url" value="file://$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
  	<arg name="frame_id" default="left_optical"/>
 	<arg name="trig_timestamp_topic" default=""/>
 	<arg name="show_debug_prints" default="false"/>

--- a/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
+++ b/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
@@ -104,6 +104,7 @@ excluded_default_topics:
   - (.*)/received_messages
   - (.*)/sent_messages
   - (.*)/scan
+  - (.*)/compressed(.*)
 
 exclude_lidar: false
 excluded_lidar_topics:

--- a/ford_fusion_sehybrid_2019/drivers.launch
+++ b/ford_fusion_sehybrid_2019/drivers.launch
@@ -89,7 +89,7 @@ If not using simulated drivers they are activated if the respective mock argumen
   <include if="$(arg avt_vimba_camera)" file="$(find avt_vimba_camera)/launch/mono_camera.launch">
 	<arg name="guid" default=""/>
  	<arg name="ip" default="192.168.30.10"/>
-    <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
+    <arg name="camera_info_url" value="file://$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
  	<arg name="frame_id" default="left_optical"/>
 	<arg name="trig_timestamp_topic" default=""/>
 	<arg name="show_debug_prints" default="false"/>

--- a/freightliner_cascadia_2012_dot_10002/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10002/VehicleConfigParams.yaml
@@ -108,6 +108,7 @@ excluded_default_topics:
   - (.*)/received_messages
   - (.*)/sent_messages
   - (.*)/scan
+  - (.*)/compressed(.*)
 
 exclude_lidar: true
 excluded_lidar_topics:

--- a/freightliner_cascadia_2012_dot_10002/drivers.launch
+++ b/freightliner_cascadia_2012_dot_10002/drivers.launch
@@ -120,7 +120,7 @@ If not using simulated drivers they are activated if the respective mock argumen
     <include if="$(arg avt_vimba_camera)" file="$(find avt_vimba_camera)/launch/mono_camera.launch">
       <arg name="guid" default=""/>
       <arg name="ip" default="192.168.30.10"/>
-      <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
+      <arg name="camera_info_url" value="file://$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
       <arg name="frame_id" default="left_optical"/>
       <arg name="trig_timestamp_topic" default=""/>
       <arg name="show_debug_prints" default="false"/>

--- a/freightliner_cascadia_2012_dot_10003/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10003/VehicleConfigParams.yaml
@@ -107,6 +107,7 @@ excluded_default_topics:
   - (.*)/received_messages
   - (.*)/sent_messages
   - (.*)/scan
+  - (.*)/compressed(.*)
 
 exclude_lidar: true
 excluded_lidar_topics:

--- a/freightliner_cascadia_2012_dot_10003/drivers.launch
+++ b/freightliner_cascadia_2012_dot_10003/drivers.launch
@@ -120,7 +120,7 @@ If not using simulated drivers they are activated if the respective mock argumen
     <include if="$(arg avt_vimba_camera)" file="$(find avt_vimba_camera)/launch/mono_camera.launch">
       <arg name="guid" default=""/>
       <arg name="ip" default="192.168.30.10"/>
-      <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
+      <arg name="camera_info_url" value="file://$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
       <arg name="frame_id" default="left_optical"/>
       <arg name="trig_timestamp_topic" default=""/>
       <arg name="show_debug_prints" default="false"/>

--- a/freightliner_cascadia_2012_dot_10004/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10004/VehicleConfigParams.yaml
@@ -107,6 +107,7 @@ excluded_default_topics:
   - (.*)/received_messages
   - (.*)/sent_messages
   - (.*)/scan
+  - (.*)/compressed(.*)
 
 exclude_lidar: true
 excluded_lidar_topics:

--- a/freightliner_cascadia_2012_dot_10004/drivers.launch
+++ b/freightliner_cascadia_2012_dot_10004/drivers.launch
@@ -120,7 +120,7 @@ If not using simulated drivers they are activated if the respective mock argumen
     <include if="$(arg avt_vimba_camera)" file="$(find avt_vimba_camera)/launch/mono_camera.launch">
       <arg name="guid" default=""/>
       <arg name="ip" default="192.168.30.10"/>
-      <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
+      <arg name="camera_info_url" value="file://$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
       <arg name="frame_id" default="left_optical"/>
       <arg name="trig_timestamp_topic" default=""/>
       <arg name="show_debug_prints" default="false"/>

--- a/freightliner_cascadia_2012_dot_80550/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_80550/VehicleConfigParams.yaml
@@ -107,6 +107,7 @@ excluded_default_topics:
   - (.*)/received_messages
   - (.*)/sent_messages
   - (.*)/scan
+  - (.*)/compressed(.*)
 
 exclude_lidar: true
 excluded_lidar_topics:

--- a/freightliner_cascadia_2012_dot_80550/drivers.launch
+++ b/freightliner_cascadia_2012_dot_80550/drivers.launch
@@ -120,7 +120,7 @@ If not using simulated drivers they are activated if the respective mock argumen
     <include if="$(arg avt_vimba_camera)" file="$(find avt_vimba_camera)/launch/mono_camera.launch">
       <arg name="guid" default=""/>
       <arg name="ip" default="192.168.30.10"/>
-      <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
+      <arg name="camera_info_url" value="file://$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
       <arg name="frame_id" default="left_optical"/>
       <arg name="trig_timestamp_topic" default=""/>
       <arg name="show_debug_prints" default="false"/>

--- a/lexus_rx_450h_2019/VehicleConfigParams.yaml
+++ b/lexus_rx_450h_2019/VehicleConfigParams.yaml
@@ -103,6 +103,7 @@ excluded_default_topics:
   - (.*)/received_messages
   - (.*)/sent_messages
   - (.*)/scan
+  - (.*)/compressed(.*)
 
 exclude_lidar: false
 excluded_lidar_topics:

--- a/lexus_rx_450h_2019/drivers.launch
+++ b/lexus_rx_450h_2019/drivers.launch
@@ -89,7 +89,7 @@ If not using simulated drivers they are activated if the respective mock argumen
     <include if="$(arg avt_vimba_camera)" file="$(find avt_vimba_camera)/launch/mono_camera.launch">
 	<arg name="guid" default=""/>
  	<arg name="ip" default="192.168.40.10"/>
-  <arg name="camera_info_url" value="$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
+  <arg name="camera_info_url" value="file://$(arg vehicle_calibration_dir)/avt_vimba_camera/camera_fl_intrinsics.yaml"/>
  	<arg name="frame_id" default="left_optical"/>
 	<arg name="trig_timestamp_topic" default=""/>
 	<arg name="show_debug_prints" default="false"/>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This fixes avt vimba not being able to find camera intrinsic calibration. All topics such related with compressed andcompressedDepth are omitted in recording in rosbag as they give error as Depth requires different channel than what we are using which rbg8 (monocular camera).See below.

![image](https://user-images.githubusercontent.com/20613282/108220203-7d3eaf00-7104-11eb-9104-553bcec0bff2.png)

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1071
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration tested on Black pacifica, Ford Fusion, Blue Lexus
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.