### PR TITLE
Update platform tag number to 3.7.1 for hotfix

### DIFF
--- a/carla_integration/docker-compose.yml
+++ b/carla_integration/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: platform
     volumes_from:
@@ -62,7 +62,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch'
 
   mock-gnss-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-gnss-driver
     volumes_from: 
@@ -75,7 +75,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=gnss'
 
   mock-lidar-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-lidar-driver
     volumes_from: 

--- a/carla_integration/docker-compose.yml
+++ b/carla_integration/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/drivers.launch'
 
   mock-gnss-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-gnss-driver
     volumes_from: 
@@ -75,7 +75,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=gnss'
 
   mock-lidar-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-lidar-driver
     volumes_from: 

--- a/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: platform
     runtime: nvidia

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: platform
     volumes_from: 
@@ -49,7 +49,7 @@ services:
     command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'
 
   mock-lightbar-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-lightbar-driver
     volumes_from: 
@@ -64,7 +64,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:="lightbar bag_parser"'
 
   mock-can-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-can-driver
     volumes_from: 
@@ -78,7 +78,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=can'
 
   mock-comms-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-comms-driver
     volumes_from: 
@@ -92,7 +92,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=comms'
 
   mock-controller-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-srx-controller-driver
     volumes_from: 
@@ -106,7 +106,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=controller'
 
   mock-radar-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-radar-driver
     volumes_from: 
@@ -120,7 +120,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=radar'
 
   mock-gnss-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-gnss-driver
     volumes_from: 
@@ -134,7 +134,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=gnss'
 
   mock-imu-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-imu-driver
     volumes_from: 
@@ -148,7 +148,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=imu'
 
   mock-lidar-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-lidar-driver
     volumes_from: 
@@ -162,7 +162,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=lidar'
 
   mock-camera-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-camera-driver
     volumes_from: 
@@ -176,7 +176,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=camera'
     
   mock-roadway-sensor-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-mock-roadway-sensor-driver
     volumes_from: 

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'
 
   mock-lightbar-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-lightbar-driver
     volumes_from: 
@@ -64,7 +64,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:="lightbar bag_parser"'
 
   mock-can-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-can-driver
     volumes_from: 
@@ -78,7 +78,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=can'
 
   mock-comms-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-comms-driver
     volumes_from: 
@@ -92,7 +92,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=comms'
 
   mock-controller-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-srx-controller-driver
     volumes_from: 
@@ -106,7 +106,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=controller'
 
   mock-radar-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-radar-driver
     volumes_from: 
@@ -120,7 +120,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=radar'
 
   mock-gnss-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-gnss-driver
     volumes_from: 
@@ -134,7 +134,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=gnss'
 
   mock-imu-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-imu-driver
     volumes_from: 
@@ -148,7 +148,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=imu'
 
   mock-lidar-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-lidar-driver
     volumes_from: 
@@ -162,7 +162,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=lidar'
 
   mock-camera-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-camera-driver
     volumes_from: 
@@ -176,7 +176,7 @@ services:
     command: bash -c 'export ROS_NAMESPACE=$${CARMA_INTR_NS} && wait-for-it.sh localhost:11311 -- roslaunch carma mock_drivers.launch mock_drivers:=camera'
     
   mock-roadway-sensor-driver:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-mock-roadway-sensor-driver
     volumes_from: 

--- a/ford_fusion_sehybrid_2019/docker-compose.yml
+++ b/ford_fusion_sehybrid_2019/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: platform
     volumes_from:

--- a/freightliner_cascadia_2012_dot_10002/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10002/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'
 
   truck-inspection:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-truck-inspection
     volumes_from: 

--- a/freightliner_cascadia_2012_dot_10002/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10002/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: platform
     runtime: nvidia
@@ -50,7 +50,7 @@ services:
     command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'
 
   truck-inspection:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-truck-inspection
     volumes_from: 

--- a/freightliner_cascadia_2012_dot_10003/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10003/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'
 
   truck-inspection:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-truck-inspection
     volumes_from:

--- a/freightliner_cascadia_2012_dot_10003/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10003/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: platform
     runtime: nvidia
@@ -50,7 +50,7 @@ services:
     command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'
 
   truck-inspection:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-truck-inspection
     volumes_from:

--- a/freightliner_cascadia_2012_dot_10004/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10004/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'
 
   truck-inspection:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-truck-inspection
     volumes_from:

--- a/freightliner_cascadia_2012_dot_10004/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10004/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: platform
     runtime: nvidia
@@ -50,7 +50,7 @@ services:
     command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'
 
   truck-inspection:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-truck-inspection
     volumes_from:

--- a/freightliner_cascadia_2012_dot_80550/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_80550/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'
 
   truck-inspection:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.1
+    image: usdotfhwastol/carma-platform:carma-system-3.7.0
     network_mode: host
     container_name: carma-truck-inspection
     volumes_from:

--- a/freightliner_cascadia_2012_dot_80550/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_80550/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: platform
     runtime: nvidia
@@ -50,7 +50,7 @@ services:
     command: bash -c 'wait-for-it.sh localhost:11311 -- roslaunch /opt/carma/vehicle/config/carma_docker.launch'
 
   truck-inspection:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: carma-truck-inspection
     volumes_from:

--- a/lexus_rx_450h_2019/docker-compose.yml
+++ b/lexus_rx_450h_2019/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.0
+    image: usdotfhwastol/carma-platform:carma-system-3.7.1
     network_mode: host
     container_name: platform
     volumes_from:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Updating image tag numbers to 3.7.1 to accommodate recent hotfixes 

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/pull/1423
https://github.com/usdot-fhwa-stol/carma-platform/issue/1426
https://github.com/usdot-fhwa-stol/carma-platform/issue/1427

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Black Pacifica tested at ACM
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.