### PR TITLE
Revert "Hotfix/2.7.2 release"

### DIFF
--- a/carla_integration/docker-compose.yml
+++ b/carla_integration/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.2
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: platform
     volumes_from:

--- a/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.2
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: platform
     runtime: nvidia

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.2
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: platform
     volumes_from: 

--- a/ford_fusion_sehybrid_2019/docker-compose.yml
+++ b/ford_fusion_sehybrid_2019/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.2
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: platform
     volumes_from:

--- a/freightliner_cascadia_2012_dot_10002/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10002/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.2
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: platform
     runtime: nvidia

--- a/freightliner_cascadia_2012_dot_10003/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10003/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.2
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: platform
     runtime: nvidia

--- a/freightliner_cascadia_2012_dot_10004/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10004/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.2
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: platform
     runtime: nvidia

--- a/freightliner_cascadia_2012_dot_80550/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_80550/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.2
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: platform
     runtime: nvidia

--- a/lexus_rx_450h_2019/docker-compose.yml
+++ b/lexus_rx_450h_2019/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: roscore
 
   platform:
-    image: usdotfhwastol/carma-platform:carma-system-3.7.2
+    image: usdotfhwastoldev/carma-platform:develop
     network_mode: host
     container_name: platform
     volumes_from:


### PR DESCRIPTION
Reverts usdot-fhwa-stol/carma-config#132, was merged into develop instead of master in error.