### PR TITLE
Update the device id for the Dataspeed USB CAN Tool following ubuntu …

### DIFF
--- a/ford_fusion_sehybrid_2019/docker-compose.yml
+++ b/ford_fusion_sehybrid_2019/docker-compose.yml
@@ -81,8 +81,8 @@ services:
     container_name: ssc_controller_driver
     network_mode: host
     privileged: true # Grant access to usb for can data
-    devices: # Data speed can tool at bus 1 device 6
-      - /dev/bus/usb/001/006:/dev/bus/usb/001/006
+    devices: # Data speed can tool at bus 1 device 3
+      - /dev/bus/usb/001/003:/dev/bus/usb/001/003
     volumes_from:
       - container:carma-config:ro
     environment:


### PR DESCRIPTION
…20.04 PC upgrade

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The ford fusion was updated to Ubuntu 20.04, as such the device id of the USB can tool changed. This PR corrects it to the new value. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Functional ford fusion
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Verified carma-platform can drive the vehicle 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.