### PR TITLE
Fix/vehicle calibrations

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
@@ -131,6 +131,7 @@ services:
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/drivers.launch.py drivers:=carma_novatel_driver_wrapper'
 
   velodyne_lidar_driver:

--- a/chrysler_pacifica_ehybrid_s_2019/drivers.launch.py
+++ b/chrysler_pacifica_ehybrid_s_2019/drivers.launch.py
@@ -87,7 +87,8 @@ def generate_launch_description():
                 launch_arguments = { 
                     'log_level' : GetLogLevel('carma_novatel_driver_wrapper', env_log_levels),
                     'ip_addr' : '192.168.88.29',
-                    'port' : '2000'
+                    'port' : '2000',
+                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/ford_fusion_sehybrid_2019/docker-compose.yml
+++ b/ford_fusion_sehybrid_2019/docker-compose.yml
@@ -133,6 +133,7 @@ services:
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/drivers.launch.py drivers:=carma_novatel_driver_wrapper'
 
   velodyne_lidar_driver:

--- a/ford_fusion_sehybrid_2019/drivers.launch.py
+++ b/ford_fusion_sehybrid_2019/drivers.launch.py
@@ -87,7 +87,8 @@ def generate_launch_description():
                 launch_arguments = { 
                     'log_level' : GetLogLevel('carma_novatel_driver_wrapper', env_log_levels),
                     'ip_addr' : '192.168.88.29',
-                    'port' : '2000'
+                    'port' : '2000',
+                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/freightliner_cascadia_2012_dot_10002/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10002/docker-compose.yml
@@ -148,6 +148,7 @@ services:
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/drivers.launch.py drivers:=carma_novatel_driver_wrapper'
 
   velodyne_lidar_driver:

--- a/freightliner_cascadia_2012_dot_10002/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10002/drivers.launch.py
@@ -107,7 +107,8 @@ def generate_launch_description():
                 launch_arguments = { 
                     'log_level' : GetLogLevel('carma_novatel_driver_wrapper', env_log_levels),
                     'ip_addr' : '192.168.88.29',
-                    'port' : '2000'
+                    'port' : '2000',
+                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/freightliner_cascadia_2012_dot_10003/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10003/docker-compose.yml
@@ -148,6 +148,7 @@ services:
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/drivers.launch.py drivers:=carma_novatel_driver_wrapper'
 
   velodyne_lidar_driver:

--- a/freightliner_cascadia_2012_dot_10003/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10003/drivers.launch.py
@@ -107,7 +107,8 @@ def generate_launch_description():
                 launch_arguments = { 
                     'log_level' : GetLogLevel('carma_novatel_driver_wrapper', env_log_levels),
                     'ip_addr' : '192.168.88.29',
-                    'port' : '2000'
+                    'port' : '2000',
+                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/freightliner_cascadia_2012_dot_10004/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10004/docker-compose.yml
@@ -148,6 +148,7 @@ services:
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/drivers.launch.py drivers:=carma_novatel_driver_wrapper'
 
   velodyne_lidar_driver:

--- a/freightliner_cascadia_2012_dot_10004/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10004/drivers.launch.py
@@ -107,7 +107,8 @@ def generate_launch_description():
                 launch_arguments = { 
                     'log_level' : GetLogLevel('carma_novatel_driver_wrapper', env_log_levels),
                     'ip_addr' : '192.168.88.29',
-                    'port' : '2000'
+                    'port' : '2000',
+                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/freightliner_cascadia_2012_dot_80550/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_80550/docker-compose.yml
@@ -148,6 +148,7 @@ services:
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/drivers.launch.py drivers:=carma_novatel_driver_wrapper'
 
   velodyne_lidar_driver:

--- a/freightliner_cascadia_2012_dot_80550/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_80550/drivers.launch.py
@@ -108,7 +108,8 @@ def generate_launch_description():
                 launch_arguments = { 
                     'log_level' : GetLogLevel('carma_novatel_driver_wrapper', env_log_levels),
                     'ip_addr' : '192.168.88.29',
-                    'port' : '2000'
+                    'port' : '2000',
+                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/lexus_rx_450h_2019/docker-compose.yml
+++ b/lexus_rx_450h_2019/docker-compose.yml
@@ -135,6 +135,7 @@ services:
     volumes:
       - /opt/carma/logs:/opt/carma/logs
       - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/drivers.launch.py drivers:=carma_novatel_driver_wrapper'
 
   velodyne_lidar_driver:

--- a/lexus_rx_450h_2019/drivers.launch.py
+++ b/lexus_rx_450h_2019/drivers.launch.py
@@ -87,7 +87,8 @@ def generate_launch_description():
                 launch_arguments = { 
                     'log_level' : GetLogLevel('carma_novatel_driver_wrapper', env_log_levels),
                     'ip_addr' : '192.168.74.10',
-                    'port' : '2000'
+                    'port' : '2000',
+                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR creates a volume for vehicle calibration on all novatel containers since they need access to that now. This path is also passed in via drivers.launch.py
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1645
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Without this the gnss_fix_fused topic will only publish at 1Hz
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
On the black pacifica
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.