### PR TITLE
make ros1_bridge ROS_IP match other docker containers

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     volumes_from:
       - container:carma-config:ro
     environment:
-      - ROS_IP=127.0.0.1
+      - ROS_IP=192.168.88.10
       - ROS_MASTER_URI=http://localhost:11311
     volumes:
       - /opt/carma/logs:/opt/carma/logs

--- a/ford_fusion_sehybrid_2019/docker-compose.yml
+++ b/ford_fusion_sehybrid_2019/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     volumes_from:
       - container:carma-config:ro
     environment:
-      - ROS_IP=127.0.0.1
+      - ROS_IP=192.168.88.10
       - ROS_MASTER_URI=http://localhost:11311
     volumes:
       - /opt/carma/logs:/opt/carma/logs

--- a/freightliner_cascadia_2012_dot_10002/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10002/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     volumes_from:
       - container:carma-config:ro
     environment:
-      - ROS_IP=127.0.0.1
+      - ROS_IP=192.168.88.10
       - ROS_MASTER_URI=http://localhost:11311
     volumes:
       - /opt/carma/logs:/opt/carma/logs

--- a/freightliner_cascadia_2012_dot_10003/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10003/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     volumes_from:
       - container:carma-config:ro
     environment:
-      - ROS_IP=127.0.0.1
+      - ROS_IP=192.168.88.10
       - ROS_MASTER_URI=http://localhost:11311
     volumes:
       - /opt/carma/logs:/opt/carma/logs

--- a/freightliner_cascadia_2012_dot_10004/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10004/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     volumes_from:
       - container:carma-config:ro
     environment:
-      - ROS_IP=127.0.0.1
+      - ROS_IP=192.168.88.10
       - ROS_MASTER_URI=http://localhost:11311
     volumes:
       - /opt/carma/logs:/opt/carma/logs

--- a/freightliner_cascadia_2012_dot_80550/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_80550/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     volumes_from:
       - container:carma-config:ro
     environment:
-      - ROS_IP=127.0.0.1
+      - ROS_IP=192.168.88.10
       - ROS_MASTER_URI=http://localhost:11311
     volumes:
       - /opt/carma/logs:/opt/carma/logs


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the ROS_IP environment variable to the same value as used in the other docker containers for each config. It was previously set to the loopback address on every config except the lexus. This is a bit of a shot in the dark to resolve the linked issue, but I have yet to see the issue appear following this change on the black pacifica. In the past setting the ROS_IP did help improve the stability of ROSJava so maybe it will have a similar impact here. 
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1653
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Stable launch of carma-platform
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested for about 10 launches in black pacifica
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.