### PR TITLE
Updated all vehicle configs to support control plugin switchover

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
+++ b/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
@@ -98,7 +98,16 @@ camera_drivers:
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:car"
 
+# Time that a guidance control plugin will continue to run after its input trajectory stops
+# Value type: Desired
+# Units: ms
+control_plugin_shutdown_timeout: 200
 
+# Num trajectory inputs that a control plugin will ignore upon first being requested
+# (a positive value helps to enforce that it won't overwrite the previous control plugin's
+# output before its shutdown timeout expires)
+# Value type: Desired
+control_plugin_ignore_initial_inputs: 0
 
 # Parameter to enable configurable speed limit
 # Value type: Desired

--- a/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
+++ b/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
@@ -98,6 +98,17 @@ camera_drivers:
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:car"
 
+# Time that a guidance control plugin will continue to run after its input trajectory stops
+# Value type: Desired
+# Units: ms
+control_plugin_shutdown_timeout: 200
+
+# Num trajectory inputs that a control plugin will ignore upon first being requested
+# (a positive value helps to enforce that it won't overwrite the previous control plugin's
+# output before its shutdown timeout expires)
+# Value type: Desired
+control_plugin_ignore_initial_inputs: 0
+
 # Parameter to enable configurable speed limit
 # Value type: Desired
 config_speed_limit: 45.0

--- a/freightliner_cascadia_2012_dot_10002/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10002/VehicleConfigParams.yaml
@@ -102,6 +102,17 @@ camera_drivers:
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:truck"
 
+# Time that a guidance control plugin will continue to run after its input trajectory stops
+# Value type: Desired
+# Units: ms
+control_plugin_shutdown_timeout: 200
+
+# Num trajectory inputs that a control plugin will ignore upon first being requested
+# (a positive value helps to enforce that it won't overwrite the previous control plugin's
+# output before its shutdown timeout expires)
+# Value type: Desired
+control_plugin_ignore_initial_inputs: 0
+
 # Parameter to enable configurable speed limit
 # Value type: Desired
 config_speed_limit: 45.0

--- a/freightliner_cascadia_2012_dot_10003/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10003/VehicleConfigParams.yaml
@@ -102,6 +102,17 @@ camera_drivers:
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:truck"
 
+# Time that a guidance control plugin will continue to run after its input trajectory stops
+# Value type: Desired
+# Units: ms
+control_plugin_shutdown_timeout: 200
+
+# Num trajectory inputs that a control plugin will ignore upon first being requested
+# (a positive value helps to enforce that it won't overwrite the previous control plugin's
+# output before its shutdown timeout expires)
+# Value type: Desired
+control_plugin_ignore_initial_inputs: 0
+
 # Parameter to enable configurable speed limit
 # Value type: Desired
 config_speed_limit: 45.0

--- a/freightliner_cascadia_2012_dot_10004/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10004/VehicleConfigParams.yaml
@@ -102,6 +102,17 @@ camera_drivers:
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:truck"
 
+# Time that a guidance control plugin will continue to run after its input trajectory stops
+# Value type: Desired
+# Units: ms
+control_plugin_shutdown_timeout: 200
+
+# Num trajectory inputs that a control plugin will ignore upon first being requested
+# (a positive value helps to enforce that it won't overwrite the previous control plugin's
+# output before its shutdown timeout expires)
+# Value type: Desired
+control_plugin_ignore_initial_inputs: 0
+
 # Parameter to enable configurable speed limit
 # Value type: Desired
 config_speed_limit: 45.0

--- a/freightliner_cascadia_2012_dot_80550/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_80550/VehicleConfigParams.yaml
@@ -102,6 +102,17 @@ camera_drivers:
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:truck"
 
+# Time that a guidance control plugin will continue to run after its input trajectory stops
+# Value type: Desired
+# Units: ms
+control_plugin_shutdown_timeout: 200
+
+# Num trajectory inputs that a control plugin will ignore upon first being requested
+# (a positive value helps to enforce that it won't overwrite the previous control plugin's
+# output before its shutdown timeout expires)
+# Value type: Desired
+control_plugin_ignore_initial_inputs: 0
+
 # Parameter to enable configurable speed limit
 # Value type: Desired
 config_speed_limit: 45.0

--- a/lexus_rx_450h_2019/VehicleConfigParams.yaml
+++ b/lexus_rx_450h_2019/VehicleConfigParams.yaml
@@ -98,6 +98,17 @@ camera_drivers:
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:car"
 
+# Time that a guidance control plugin will continue to run after its input trajectory stops
+# Value type: Desired
+# Units: ms
+control_plugin_shutdown_timeout: 200
+
+# Num trajectory inputs that a control plugin will ignore upon first being requested
+# (a positive value helps to enforce that it won't overwrite the previous control plugin's
+# output before its shutdown timeout expires)
+# Value type: Desired
+control_plugin_ignore_initial_inputs: 0
+
 # Parameter to enable configurable speed limit
 # Value type: Desired
 config_speed_limit: 45.0


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Recent changes in the guidance control plugins to allow them to cooperate with each other when being switched from one to another requires a couple new parameters.  These params govern if/how the various control plugins overlap in writing to their common output topic.

This is set to merge into feature/ihp, which is a branch off of master at v3.11.0.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/pull/1656 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
See description in the the referenced PR.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.