### PR TITLE
Fix/shutdown behavior

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/drivers.launch.py
+++ b/chrysler_pacifica_ehybrid_s_2019/drivers.launch.py
@@ -23,8 +23,11 @@ from launch.substitutions import PythonExpression
 from launch_ros.substitutions import FindPackageShare
 from launch.conditions import IfCondition
 from launch.actions import GroupAction
+from launch.actions import Shutdown
 from launch_ros.actions import PushRosNamespace
+from launch_ros.actions import Node
 from carma_ros2_utils.launch.get_log_level import GetLogLevel
+import uuid
 
 def generate_launch_description():
     """
@@ -48,6 +51,20 @@ def generate_launch_description():
     drivers = LaunchConfiguration('drivers')
     declare_drivers_arg = DeclareLaunchArgument(
         name = 'drivers', default_value = 'dsrc_driver velodyne_lidar_driver_wrapper', description = "Desired drivers to launch specified by package name."
+    )
+
+    # Launch shutdown node which will ensure the launch file gets closed on system shutdown even if in a separate container
+    driver_shutdown_group = GroupAction(
+        actions=[
+            PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
+            Node (
+                package='driver_shutdown_ros2',
+                executable='driver_shutdown_ros2_node_exec',
+                name=[ 'driver_shutdown_', uuid.uuid4().hex ], # No clear way to make anonymous nodes in ros2, so for now we will generate a uuid for now
+                on_exit=Shutdown(),
+                arguments=['--ros-args', '--log-level', GetLogLevel('driver_shutdown_ros2', env_log_levels)]
+            )
+        ]
     )
 
     dsrc_group = GroupAction(
@@ -99,6 +116,7 @@ def generate_launch_description():
         declare_drivers_arg,
         declare_vehicle_calibration_dir_arg,
         declare_vehicle_config_dir_arg,
+        driver_shutdown_group,
         dsrc_group,
         lidar_group,
         gnss_ins_group

--- a/ford_fusion_sehybrid_2019/drivers.launch.py
+++ b/ford_fusion_sehybrid_2019/drivers.launch.py
@@ -23,8 +23,11 @@ from launch.substitutions import PythonExpression
 from launch_ros.substitutions import FindPackageShare
 from launch.conditions import IfCondition
 from launch.actions import GroupAction
+from launch.actions import Shutdown
 from launch_ros.actions import PushRosNamespace
+from launch_ros.actions import Node
 from carma_ros2_utils.launch.get_log_level import GetLogLevel
+import uuid
 
 def generate_launch_description():
     """
@@ -48,6 +51,20 @@ def generate_launch_description():
     drivers = LaunchConfiguration('drivers')
     declare_drivers_arg = DeclareLaunchArgument(
         name = 'drivers', default_value = 'dsrc_driver velodyne_lidar_driver_wrapper', description = "Desired drivers to launch specified by package name."
+    )
+
+    # Launch shutdown node which will ensure the launch file gets closed on system shutdown even if in a separate container
+    driver_shutdown_group = GroupAction(
+        actions=[
+            PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
+            Node (
+                package='driver_shutdown_ros2',
+                executable='driver_shutdown_ros2_node_exec',
+                name=[ 'driver_shutdown_', uuid.uuid4().hex ], # No clear way to make anonymous nodes in ros2, so for now we will generate a uuid for now
+                on_exit=Shutdown(),
+                arguments=['--ros-args', '--log-level', GetLogLevel('driver_shutdown_ros2', env_log_levels)]
+            )
+        ]
     )
 
     dsrc_group = GroupAction(
@@ -98,6 +115,7 @@ def generate_launch_description():
         declare_drivers_arg,
         declare_vehicle_calibration_dir_arg,
         declare_vehicle_config_dir_arg,
+        driver_shutdown_group,
         dsrc_group,
         lidar_group,
         gnss_ins_group

--- a/lexus_rx_450h_2019/drivers.launch.py
+++ b/lexus_rx_450h_2019/drivers.launch.py
@@ -23,9 +23,12 @@ from launch.substitutions import PythonExpression
 from launch_ros.substitutions import FindPackageShare
 from launch.conditions import IfCondition
 from launch.actions import GroupAction
+from launch.actions import Shutdown
 from launch_ros.actions import PushRosNamespace
+from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 from carma_ros2_utils.launch.get_log_level import GetLogLevel
+import uuid
 
 def generate_launch_description():
     """
@@ -49,6 +52,20 @@ def generate_launch_description():
     drivers = LaunchConfiguration('drivers')
     declare_drivers_arg = DeclareLaunchArgument(
         name = 'drivers', default_value = 'dsrc_driver velodyne_lidar_driver_wrapper carma_novatel_driver_wrapper', description = "Desired drivers to launch specified by package name."
+    )
+
+    # Launch shutdown node which will ensure the launch file gets closed on system shutdown even if in a separate container
+    driver_shutdown_group = GroupAction(
+        actions=[
+            PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
+            Node (
+                package='driver_shutdown_ros2',
+                executable='driver_shutdown_ros2_node_exec',
+                name=[ 'driver_shutdown_', uuid.uuid4().hex ], # No clear way to make anonymous nodes in ros2, so for now we will generate a uuid for now
+                on_exit=Shutdown(),
+                arguments=['--ros-args', '--log-level', GetLogLevel('driver_shutdown_ros2', env_log_levels)]
+            )
+        ]
     )
 
     dsrc_group = GroupAction(
@@ -117,6 +134,7 @@ def generate_launch_description():
         declare_drivers_arg,
         declare_vehicle_calibration_dir_arg,
         declare_vehicle_config_dir_arg,
+        driver_shutdown_group,
         dsrc_group,
         ssc_group,
         lidar_group,


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds the driver shutdown node to all drivers.launch.py files such that a shutdown system alert message will cause a full exit of the top level launch file in each driver container. 
<!--- Describe your changes in detail -->

## Related Issue
Supports https://github.com/usdot-fhwa-stol/carma-platform/issues/1702
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Reliable shutdown
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on silver lexus with lidar to gps failover
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x]Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.