### PR TITLE
change bridge map_pub direction carma_wm_ctrl_ros2 support

### DIFF
--- a/carla_integration/bridge.yml
+++ b/carla_integration/bridge.yml
@@ -19,7 +19,7 @@ topics:
     topic: /environment/semantic_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_last
       depth: 1
@@ -28,7 +28,7 @@ topics:
     topic: /environment/map_update
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 200
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_all
       durability: transient_local

--- a/chrysler_pacifica_ehybrid_s_2019/bridge.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/bridge.yml
@@ -19,7 +19,7 @@ topics:
     topic: /environment/semantic_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_last
       depth: 1
@@ -28,7 +28,7 @@ topics:
     topic: /environment/map_update
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 200
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_all
       durability: transient_local

--- a/development/bridge.yml
+++ b/development/bridge.yml
@@ -19,7 +19,7 @@ topics:
     topic: /environment/semantic_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_last
       depth: 1
@@ -28,11 +28,11 @@ topics:
     topic: /environment/map_update
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 200
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_all
       durability: transient_local
--
+  -
     topic: /environment/external_object_predictions
     type: carma_perception_msgs/msg/ExternalObjectList
     queue_size: 1

--- a/ford_fusion_sehybrid_2019/bridge.yml
+++ b/ford_fusion_sehybrid_2019/bridge.yml
@@ -19,7 +19,7 @@ topics:
     topic: /environment/semantic_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_last
       depth: 1
@@ -28,7 +28,7 @@ topics:
     topic: /environment/map_update
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 200
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_all
       durability: transient_local

--- a/freightliner_cascadia_2012_dot_10002/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10002/bridge.yml
@@ -19,7 +19,7 @@ topics:
     topic: /environment/semantic_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_last
       depth: 1
@@ -28,7 +28,7 @@ topics:
     topic: /environment/map_update
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 200
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_all
       durability: transient_local

--- a/freightliner_cascadia_2012_dot_10003/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10003/bridge.yml
@@ -19,7 +19,7 @@ topics:
     topic: /environment/semantic_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_last
       depth: 1
@@ -28,7 +28,7 @@ topics:
     topic: /environment/map_update
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 200
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_all
       durability: transient_local

--- a/freightliner_cascadia_2012_dot_10004/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10004/bridge.yml
@@ -19,7 +19,7 @@ topics:
     topic: /environment/semantic_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_last
       depth: 1
@@ -28,7 +28,7 @@ topics:
     topic: /environment/map_update
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 200
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_all
       durability: transient_local

--- a/freightliner_cascadia_2012_dot_80550/bridge.yml
+++ b/freightliner_cascadia_2012_dot_80550/bridge.yml
@@ -19,7 +19,7 @@ topics:
     topic: /environment/semantic_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_last
       depth: 1
@@ -28,7 +28,7 @@ topics:
     topic: /environment/map_update
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 200
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_all
       durability: transient_local

--- a/lexus_rx_450h_2019/bridge.yml
+++ b/lexus_rx_450h_2019/bridge.yml
@@ -19,7 +19,7 @@ topics:
     topic: /environment/semantic_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_last
       depth: 1
@@ -28,7 +28,7 @@ topics:
     topic: /environment/map_update
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 200
-    direction: 1to2
+    direction: 2to1
     qos:
       history: keep_all
       durability: transient_local


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Supports https://github.com/usdot-fhwa-stol/carma-platform/pull/1792

Since carma_wm_ctrl is ROS2 now, the map and map_update direction is revised to 2to1

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1793
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See above.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration tested.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.