### PR TITLE
Add latching to system_alert

### DIFF
--- a/carla_integration/bridge.yml
+++ b/carla_integration/bridge.yml
@@ -40,4 +40,8 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
+    qos:
+      history: keep_last
+      depth: 5
+      durability: transient_local
 services_1_to_2: []

--- a/chrysler_pacifica_ehybrid_s_2019/bridge.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/bridge.yml
@@ -40,4 +40,8 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
+    qos:
+      history: keep_last
+      depth: 5
+      durability: transient_local
 services_1_to_2: []

--- a/development/bridge.yml
+++ b/development/bridge.yml
@@ -40,4 +40,8 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
+    qos:
+      history: keep_last
+      depth: 5
+      durability: transient_local
 services_1_to_2: []

--- a/ford_fusion_sehybrid_2019/bridge.yml
+++ b/ford_fusion_sehybrid_2019/bridge.yml
@@ -40,4 +40,8 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
+    qos:
+      history: keep_last
+      depth: 5
+      durability: transient_local
 services_1_to_2: []

--- a/freightliner_cascadia_2012_dot_10002/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10002/bridge.yml
@@ -40,4 +40,8 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
+    qos:
+      history: keep_last
+      depth: 5
+      durability: transient_local
 services_1_to_2: []

--- a/freightliner_cascadia_2012_dot_10003/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10003/bridge.yml
@@ -40,4 +40,8 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
+    qos:
+      history: keep_last
+      depth: 5
+      durability: transient_local
 services_1_to_2: []

--- a/freightliner_cascadia_2012_dot_10004/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10004/bridge.yml
@@ -40,4 +40,8 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
+    qos:
+      history: keep_last
+      depth: 5
+      durability: transient_local
 services_1_to_2: []

--- a/freightliner_cascadia_2012_dot_80550/bridge.yml
+++ b/freightliner_cascadia_2012_dot_80550/bridge.yml
@@ -40,4 +40,8 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
+    qos:
+      history: keep_last
+      depth: 5
+      durability: transient_local
 services_1_to_2: []

--- a/lexus_rx_450h_2019/bridge.yml
+++ b/lexus_rx_450h_2019/bridge.yml
@@ -40,4 +40,8 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
+    qos:
+      history: keep_last
+      depth: 5
+      durability: transient_local
 services_1_to_2: []


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR sets the system_alert subscription in ros1_bridge to transient local with a history depth of 5. This is needed to ensure the ros2 UI can transition automatically on startup. 
<!--- Describe your changes in detail -->

## Related Issue
Supports https://github.com/usdot-fhwa-stol/carma-platform/issues/1896
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Working UI
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
local integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.