### PR TITLE
Fix/turn camera lidar logging off

### DIFF
--- a/carla_integration/VehicleConfigParams.yaml
+++ b/carla_integration/VehicleConfigParams.yaml
@@ -111,7 +111,7 @@ excluded_default_topics:
   - (.*)/sent_messages
   - (.*)/scan
 
-exclude_lidar: false
+exclude_lidar: true
 excluded_lidar_topics:
   - /detection/lidar_detector/objects
   - /detection/lidar_detector/objects_markers
@@ -124,7 +124,7 @@ excluded_lidar_topics:
   - /environment/detection/object_tracker/objects_markers
   - /environment/detection/objects
 
-exclude_camera: false
+exclude_camera: true
 excluded_camera_topics:
   - /hardware_interface/camera/camera_info
   - /hardware_interface/camera/image_raw

--- a/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
+++ b/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
@@ -203,7 +203,7 @@ excluded_default_topics:
   - /ui/client_count
   - /ui/connected_clients
 
-exclude_lidar: false
+exclude_lidar: true
 excluded_lidar_topics:
   - /detection/lidar_detector/objects
   - /detection/lidar_detector/objects_markers
@@ -216,7 +216,7 @@ excluded_lidar_topics:
   - /environment/detection/object_tracker/objects_markers
   - /environment/detection/objects
   
-exclude_camera: false
+exclude_camera: true
 excluded_camera_topics:
   - /hardware_interface/camera/camera_info
   - /hardware_interface/camera/image_raw

--- a/development/VehicleConfigParams.yaml
+++ b/development/VehicleConfigParams.yaml
@@ -110,7 +110,7 @@ excluded_default_topics:
   - (.*)/sent_messages
   - (.*)/scan
 
-exclude_lidar: false
+exclude_lidar: true
 excluded_lidar_topics:
   - /detection/lidar_detector/objects
   - /detection/lidar_detector/objects_markers
@@ -123,7 +123,7 @@ excluded_lidar_topics:
   - /environment/detection/object_tracker/objects_markers
   - /environment/detection/objects
   
-exclude_camera: false
+exclude_camera: true
 excluded_camera_topics:
   - /hardware_interface/camera/camera_info
   - /hardware_interface/camera/image_raw

--- a/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
+++ b/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
@@ -201,7 +201,7 @@ excluded_default_topics:
   - /ui/client_count
   - /ui/connected_clients
 
-exclude_lidar: false
+exclude_lidar: true
 excluded_lidar_topics:
   - /detection/lidar_detector/objects
   - /detection/lidar_detector/objects_markers
@@ -214,7 +214,7 @@ excluded_lidar_topics:
   - /environment/detection/object_tracker/objects_markers
   - /environment/detection/objects
   
-exclude_camera: false
+exclude_camera: true
 excluded_camera_topics:
   - /hardware_interface/camera/camera_info
   - /hardware_interface/camera/image_raw

--- a/lexus_rx_450h_2019/VehicleConfigParams.yaml
+++ b/lexus_rx_450h_2019/VehicleConfigParams.yaml
@@ -244,7 +244,7 @@ excluded_default_topics:
   - /ui/client_count
   - /ui/connected_clients
 
-exclude_lidar: false
+exclude_lidar: true
 excluded_lidar_topics:
   - /detection/lidar_detector/objects
   - /detection/lidar_detector/objects_markers
@@ -257,7 +257,7 @@ excluded_lidar_topics:
   - /environment/detection/object_tracker/objects_markers
   - /environment/detection/objects
   
-exclude_camera: false
+exclude_camera: true
 excluded_camera_topics:
   - /hardware_interface/camera/camera_info
   - /hardware_interface/camera/image_raw

--- a/multi-vehicle-sim-demo/VehicleConfigParams.yaml
+++ b/multi-vehicle-sim-demo/VehicleConfigParams.yaml
@@ -112,7 +112,7 @@ excluded_default_topics:
   - (.*)/sent_messages
   - (.*)/scan
 
-exclude_lidar: false
+exclude_lidar: true
 excluded_lidar_topics:
   - /detection/lidar_detector/objects
   - /detection/lidar_detector/objects_markers
@@ -125,7 +125,7 @@ excluded_lidar_topics:
   - /environment/detection/object_tracker/objects_markers
   - /environment/detection/objects
 
-exclude_camera: false
+exclude_camera: true
 excluded_camera_topics:
   - /hardware_interface/camera/camera_info
   - /hardware_interface/camera/image_raw


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR turns the lidar and camera logging off by default in all configs, to minimize resource consumption. The parameters can be turned on when required.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.