### PR TITLE
add flag to enable open tunnels

### DIFF
--- a/carla_integration/carma_docker.launch.py
+++ b/carla_integration/carma_docker.launch.py
@@ -84,6 +84,14 @@ def generate_launch_description():
         description='List of String: Guidance Control Plugins that will be validated by the Guidance Plugin Validator Node if enabled'
     )
 
+    # Declare enable_opening_tunnels
+    enable_opening_tunnels = LaunchConfiguration('enable_opening_tunnels')
+    declare_enable_opening_tunnels = DeclareLaunchArgument(
+        name = 'enable_opening_tunnels',
+        default_value= 'False',
+        description='Flag to enable opening http tunnesl to CARMA Cloud'
+    )
+
     # Launch the core carma launch file
     carma_src_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([ get_package_share_directory('carma'), '/launch/carma_src.launch.py']),
@@ -107,5 +115,6 @@ def generate_launch_description():
         declare_strategic_plugins_to_validate,
         declare_tactical_plugins_to_validate,
         declare_control_plugins_to_validate,
+        enable_opening_tunnels,
         carma_src_launch
     ])

--- a/chrysler_pacifica_ehybrid_s_2019/carma_docker.launch.py
+++ b/chrysler_pacifica_ehybrid_s_2019/carma_docker.launch.py
@@ -84,6 +84,14 @@ def generate_launch_description():
         description='List of String: Guidance Control Plugins that will be validated by the Guidance Plugin Validator Node if enabled'
     )
 
+    # Declare enable_opening_tunnels
+    enable_opening_tunnels = LaunchConfiguration('enable_opening_tunnels')
+    declare_enable_opening_tunnels = DeclareLaunchArgument(
+        name = 'enable_opening_tunnels',
+        default_value= 'False',
+        description='Flag to enable opening http tunnesl to CARMA Cloud'
+    )
+
     # Launch the core carma launch file
     carma_src_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([ get_package_share_directory('carma'), '/launch/carma_src.launch.py']),
@@ -107,5 +115,6 @@ def generate_launch_description():
         declare_strategic_plugins_to_validate,
         declare_tactical_plugins_to_validate,
         declare_control_plugins_to_validate,
+        declare_enable_opening_tunnels,
         carma_src_launch
     ])

--- a/development/carma_docker.launch.py
+++ b/development/carma_docker.launch.py
@@ -84,6 +84,14 @@ def generate_launch_description():
         description='List of String: Guidance Control Plugins that will be validated by the Guidance Plugin Validator Node if enabled'
     )
 
+    # Declare enable_opening_tunnels
+    enable_opening_tunnels = LaunchConfiguration('enable_opening_tunnels')
+    declare_enable_opening_tunnels = DeclareLaunchArgument(
+        name = 'enable_opening_tunnels',
+        default_value= 'False',
+        description='Flag to enable opening http tunnesl to CARMA Cloud'
+    )
+
     # Launch the core carma launch file
     carma_src_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([ get_package_share_directory('carma'), '/launch/carma_src.launch.py']),
@@ -94,7 +102,8 @@ def generate_launch_description():
             'enable_guidance_plugin_validator' : enable_guidance_plugin_validator,
             'strategic_plugins_to_validate' : strategic_plugins_to_validate,
             'tactical_plugins_to_validate' : tactical_plugins_to_validate,
-            'control_plugins_to_validate' : control_plugins_to_validate
+            'control_plugins_to_validate' : control_plugins_to_validate,
+            'enable_opening_tunnels' : enable_opening_tunnels
             }.items()
     )
 
@@ -107,5 +116,6 @@ def generate_launch_description():
         declare_strategic_plugins_to_validate,
         declare_tactical_plugins_to_validate,
         declare_control_plugins_to_validate,
+        declare_enable_opening_tunnels,
         carma_src_launch
     ])

--- a/ford_fusion_sehybrid_2019/carma_docker.launch.py
+++ b/ford_fusion_sehybrid_2019/carma_docker.launch.py
@@ -84,6 +84,14 @@ def generate_launch_description():
         description='List of String: Guidance Control Plugins that will be validated by the Guidance Plugin Validator Node if enabled'
     )
 
+    # Declare enable_opening_tunnels
+    enable_opening_tunnels = LaunchConfiguration('enable_opening_tunnels')
+    declare_enable_opening_tunnels = DeclareLaunchArgument(
+        name = 'enable_opening_tunnels',
+        default_value= 'False',
+        description='Flag to enable opening http tunnesl to CARMA Cloud'
+    )
+
     # Launch the core carma launch file
     carma_src_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([ get_package_share_directory('carma'), '/launch/carma_src.launch.py']),
@@ -107,5 +115,6 @@ def generate_launch_description():
         declare_strategic_plugins_to_validate,
         declare_tactical_plugins_to_validate,
         declare_control_plugins_to_validate,
+        declare_enable_opening_tunnels,
         carma_src_launch
     ])

--- a/freightliner_cascadia_2012_dot_10002/carma_docker.launch.py
+++ b/freightliner_cascadia_2012_dot_10002/carma_docker.launch.py
@@ -84,6 +84,14 @@ def generate_launch_description():
         description='List of String: Guidance Control Plugins that will be validated by the Guidance Plugin Validator Node if enabled'
     )
 
+    # Declare enable_opening_tunnels
+    enable_opening_tunnels = LaunchConfiguration('enable_opening_tunnels')
+    declare_enable_opening_tunnels = DeclareLaunchArgument(
+        name = 'enable_opening_tunnels',
+        default_value= 'False',
+        description='Flag to enable opening http tunnesl to CARMA Cloud'
+    )
+
     # Launch the core carma launch file
     carma_src_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([ get_package_share_directory('carma'), '/launch/carma_src.launch.py']),
@@ -107,5 +115,6 @@ def generate_launch_description():
         declare_strategic_plugins_to_validate,
         declare_tactical_plugins_to_validate,
         declare_control_plugins_to_validate,
+        declare_enable_opening_tunnels,
         carma_src_launch
     ])

--- a/freightliner_cascadia_2012_dot_10003/carma_docker.launch.py
+++ b/freightliner_cascadia_2012_dot_10003/carma_docker.launch.py
@@ -84,6 +84,14 @@ def generate_launch_description():
         description='List of String: Guidance Control Plugins that will be validated by the Guidance Plugin Validator Node if enabled'
     )
 
+    # Declare enable_opening_tunnels
+    enable_opening_tunnels = LaunchConfiguration('enable_opening_tunnels')
+    declare_enable_opening_tunnels = DeclareLaunchArgument(
+        name = 'enable_opening_tunnels',
+        default_value= 'False',
+        description='Flag to enable opening http tunnesl to CARMA Cloud'
+    )
+
     # Launch the core carma launch file
     carma_src_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([ get_package_share_directory('carma'), '/launch/carma_src.launch.py']),
@@ -107,5 +115,6 @@ def generate_launch_description():
         declare_strategic_plugins_to_validate,
         declare_tactical_plugins_to_validate,
         declare_control_plugins_to_validate,
+        declare_enable_opening_tunnels,
         carma_src_launch
     ])

--- a/freightliner_cascadia_2012_dot_10004/carma_docker.launch.py
+++ b/freightliner_cascadia_2012_dot_10004/carma_docker.launch.py
@@ -84,6 +84,14 @@ def generate_launch_description():
         description='List of String: Guidance Control Plugins that will be validated by the Guidance Plugin Validator Node if enabled'
     )
 
+    # Declare enable_opening_tunnels
+    enable_opening_tunnels = LaunchConfiguration('enable_opening_tunnels')
+    declare_enable_opening_tunnels = DeclareLaunchArgument(
+        name = 'enable_opening_tunnels',
+        default_value= 'False',
+        description='Flag to enable opening http tunnesl to CARMA Cloud'
+    )
+
     # Launch the core carma launch file
     carma_src_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([ get_package_share_directory('carma'), '/launch/carma_src.launch.py']),
@@ -107,5 +115,6 @@ def generate_launch_description():
         declare_strategic_plugins_to_validate,
         declare_tactical_plugins_to_validate,
         declare_control_plugins_to_validate,
+        declare_enable_opening_tunnels,
         carma_src_launch
     ])

--- a/freightliner_cascadia_2012_dot_80550/carma_docker.launch.py
+++ b/freightliner_cascadia_2012_dot_80550/carma_docker.launch.py
@@ -98,6 +98,14 @@ def generate_launch_description():
             }.items()
     )
 
+    # Declare enable_opening_tunnels
+    enable_opening_tunnels = LaunchConfiguration('enable_opening_tunnels')
+    declare_enable_opening_tunnels = DeclareLaunchArgument(
+        name = 'enable_opening_tunnels',
+        default_value= 'False',
+        description='Flag to enable opening http tunnesl to CARMA Cloud'
+    )
+
     return LaunchDescription([
         logging_env_var, # Environment variables must be placed before included files
         declare_vehicle_calibration_dir_arg,
@@ -107,5 +115,6 @@ def generate_launch_description():
         declare_strategic_plugins_to_validate,
         declare_tactical_plugins_to_validate,
         declare_control_plugins_to_validate,
+        declare_enable_opening_tunnels,
         carma_src_launch
     ])

--- a/lexus_rx_450h_2019/carma_docker.launch.py
+++ b/lexus_rx_450h_2019/carma_docker.launch.py
@@ -84,6 +84,14 @@ def generate_launch_description():
         description='List of String: Guidance Control Plugins that will be validated by the Guidance Plugin Validator Node if enabled'
     )
 
+    # Declare enable_opening_tunnels
+    enable_opening_tunnels = LaunchConfiguration('enable_opening_tunnels')
+    declare_enable_opening_tunnels = DeclareLaunchArgument(
+        name = 'enable_opening_tunnels',
+        default_value= 'False',
+        description='Flag to enable opening http tunnesl to CARMA Cloud'
+    )
+
     # Launch the core carma launch file
     carma_src_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([ get_package_share_directory('carma'), '/launch/carma_src.launch.py']),
@@ -107,5 +115,6 @@ def generate_launch_description():
         declare_strategic_plugins_to_validate,
         declare_tactical_plugins_to_validate,
         declare_control_plugins_to_validate,
+        declare_enable_opening_tunnels,
         carma_src_launch
     ])


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

A flag is added to enable and disable opening HTTP tunnels to CARMA Cloud.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.