### PR TITLE
Move the RLM license environment variable from vehicle calibration to…

### DIFF
--- a/lexus_rx_450h_2019/carma.env
+++ b/lexus_rx_450h_2019/carma.env
@@ -39,5 +39,5 @@ export CARMA_UI_NS="/ui"
 ###
 
 # Lexus SSC license file location
-# Previously located in vehicle calibration this path was moved here due to this issue https://github.com/usdot-fhwa-stol/carma-platform/issues/2002
+# Previously located in ssc_interface_wrapper_ros2 this path was moved here due to this issue https://github.com/usdot-fhwa-stol/carma-platform/issues/2002
 export RLM_LICENSE="/opt/carma/vehicle/calibration/ssc_pm_lexus/as_licenses"

--- a/lexus_rx_450h_2019/carma.env
+++ b/lexus_rx_450h_2019/carma.env
@@ -33,3 +33,11 @@ export CARMA_LOCZ_NS="/localization"
 
 # Namespace of nodes in the web ui stack
 export CARMA_UI_NS="/ui"
+
+###
+# Hardware Interfaces
+###
+
+# Lexus SSC license file location
+# Previously located in vehicle calibration this path was moved here due to this issue https://github.com/usdot-fhwa-stol/carma-platform/issues/2002
+export RLM_LICENSE="/opt/carma/vehicle/calibration/ssc_pm_lexus/as_licenses"


### PR DESCRIPTION
… the config

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR moves the RLM_LICENSE environment variable configuration from the SSC launch files to the config due to an apparent issue in the usage of the environment variable setting from within ROS2 launch. Setting the variable here globally for the whole docker image resolves this issue. Since this only occurs on the ROS2 SSC (lexus) only that config has been changed. 
## Related Issue
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/2002
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Functional DBW system
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Verified in Blue and Silver lexus
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.