### PR TITLE
Update SubsystemControllerParams.yaml to auto-activate approaching_emergency_vehicle_plugin on trucks

### DIFF
--- a/freightliner_cascadia_2012_dot_10002/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_10002/SubsystemControllerParams.yaml
@@ -52,6 +52,7 @@ guidance:
         - /guidance/plugins/platoon_strategic_ihp_node
         - /guidance/plugins/platooning_tactical_plugin_node
         - /guidance/plugins/yield_plugin
+        - /guidance/plugins/approaching_emergency_vehicle_plugin
       ros2_initial_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/inlanecruising_plugin          
@@ -65,6 +66,7 @@ guidance:
         - /guidance/plugins/stop_controlled_intersection_tactical_plugin
         - /guidance/plugins/yield_plugin
         - /guidance/plugins/pure_pursuit_wrapper
+        - /guidance/plugins/approaching_emergency_vehicle_plugin
 
 localization:
   localization_controller:

--- a/freightliner_cascadia_2012_dot_10003/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_10003/SubsystemControllerParams.yaml
@@ -52,6 +52,7 @@ guidance:
         - /guidance/plugins/platoon_strategic_ihp_node
         - /guidance/plugins/platooning_tactical_plugin_node
         - /guidance/plugins/yield_plugin
+        - /guidance/plugins/approaching_emergency_vehicle_plugin
       ros2_initial_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/inlanecruising_plugin          
@@ -65,6 +66,7 @@ guidance:
         - /guidance/plugins/stop_controlled_intersection_tactical_plugin
         - /guidance/plugins/yield_plugin
         - /guidance/plugins/pure_pursuit_wrapper
+        - /guidance/plugins/approaching_emergency_vehicle_plugin
 
 localization:
   localization_controller:

--- a/freightliner_cascadia_2012_dot_10004/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_10004/SubsystemControllerParams.yaml
@@ -52,6 +52,7 @@ guidance:
         - /guidance/plugins/platoon_strategic_ihp_node
         - /guidance/plugins/platooning_tactical_plugin_node
         - /guidance/plugins/yield_plugin
+        - /guidance/plugins/approaching_emergency_vehicle_plugin
       ros2_initial_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/inlanecruising_plugin          
@@ -65,6 +66,7 @@ guidance:
         - /guidance/plugins/stop_controlled_intersection_tactical_plugin
         - /guidance/plugins/yield_plugin
         - /guidance/plugins/pure_pursuit_wrapper
+        - /guidance/plugins/approaching_emergency_vehicle_plugin
 
 localization:
   localization_controller:

--- a/freightliner_cascadia_2012_dot_80550/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_80550/SubsystemControllerParams.yaml
@@ -52,6 +52,7 @@ guidance:
         - /guidance/plugins/platoon_strategic_ihp_node
         - /guidance/plugins/platooning_tactical_plugin_node
         - /guidance/plugins/yield_plugin
+        - /guidance/plugins/approaching_emergency_vehicle_plugin
       ros2_initial_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/inlanecruising_plugin          
@@ -65,6 +66,7 @@ guidance:
         - /guidance/plugins/stop_controlled_intersection_tactical_plugin
         - /guidance/plugins/yield_plugin
         - /guidance/plugins/pure_pursuit_wrapper
+        - /guidance/plugins/approaching_emergency_vehicle_plugin
 
 localization:
   localization_controller:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR updates the SubsystemControllerParams.yaml file to auto-activate the approaching_emergency_vehicle_plugin (Strategic Plugin) on trucks. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
TODO

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
In support of the CARMA Freight Emergency Response Use Case.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Integration tested with trucks at Suntrax.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.