### PR TITLE
Added new configuration parameters for CDASim CARLA Sensor integration

### DIFF
--- a/xil_cloud/docker-compose.yml
+++ b/xil_cloud/docker-compose.yml
@@ -223,13 +223,15 @@ services:
       - TIME_SYNC_TOPIC=time_sync
       - TIME_SYNC_PORT=7575
       - SIM_V2X_PORT=1517
+      - SIM_INTERACTION_PORT=7576
       - V2X_PORT=8686
+      - SENSOR_JSON_FILE_PATH=/var/www/plugins/sensors/sensors.json
       - INFRASTRUCTURE_ID=rsu_15
-      - KAFKA_BROKER_ADDRESS= 172.4.0.3:9092
     volumes:
       - ./logs:/var/log/tmx
       - ./MAP:/var/www/plugins/MAP
       - ./secrets:/home/V2X-Hub/secrets
+      - ./sensors:/var/www/plugins/sensors
 
   intersection_model:
     image: usdotfhwastolcandidate/intersection_model:k900


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Update XIL-Cloud carma-config docker-compose for new CDASim CARLA Sensor Integration.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Support VRU CDASim testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed in XIL-Cloud environment and tested Infrastructure Registration including sensor registration.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.