### PR TITLE
add required drivers to subsystem params

### DIFF
--- a/carla_ground_truth_integration/SubsystemControllerParams.yaml
+++ b/carla_ground_truth_integration/SubsystemControllerParams.yaml
@@ -18,6 +18,13 @@ hardware_interface:
       subsystem_namespace: /hardware_interface
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: ['']
+      excluded_namespace_nodes:
+        - /hardware_interface/carla_lidar_driver
+        - /hardware_interface/carla_gnss_driver
+      ros1_required_drivers:
+       - /hardware_interface/carla_driver
+      ros1_camera_drivers:
+      - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
 
 message:

--- a/carla_ground_truth_integration/VehicleConfigParams.yaml
+++ b/carla_ground_truth_integration/VehicleConfigParams.yaml
@@ -81,20 +81,6 @@ vehicle_steer_lim_deg: 29.2
 # Unit: s
 vehicle_model_steer_tau : 0.3
 
-# Parameter to switch between passenger car and truck
-# Value type: Measured
-truck: false
-car: true
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/carla_driver
-lidar_gps_drivers:
-  - /hardware_interface/carla_lidar_driver
-  - /hardware_interface/carla_gnss_driver
-camera_drivers:
-  - /hardware_interface/carla_camera_driver
-
 # Parameter to enable configurable speed limit
 # Value type: Desired
 config_speed_limit: 20.0

--- a/chrysler_pacifica_ehybrid_s_2019/SubsystemControllerParams.yaml
+++ b/chrysler_pacifica_ehybrid_s_2019/SubsystemControllerParams.yaml
@@ -18,6 +18,13 @@ hardware_interface:
       subsystem_namespace: /hardware_interface
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: ['']
+      excluded_namespace_nodes:
+        - /hardware_interface/velodyne_lidar_driver_wrapper
+        - /hardware_interface/novatel_gps_nodelet_wrapper
+      ros1_required_drivers:
+       - /hardware_interface/ssc_interface_wrapper
+      ros1_camera_drivers:
+      - /hardware_interface/camera
       full_subsystem_required: false
 
 message:

--- a/chrysler_pacifica_ehybrid_s_2019/SubsystemControllerParams.yaml
+++ b/chrysler_pacifica_ehybrid_s_2019/SubsystemControllerParams.yaml
@@ -20,7 +20,7 @@ hardware_interface:
       unmanaged_required_nodes: ['']
       excluded_namespace_nodes:
         - /hardware_interface/velodyne_lidar_driver_wrapper
-        - /hardware_interface/novatel_gps_nodelet_wrapper
+        - /hardware_interface/carma_novatel_driver_wrapper_node
       ros1_required_drivers:
        - /hardware_interface/ssc_interface_wrapper
       ros1_camera_drivers:

--- a/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
+++ b/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
@@ -80,20 +80,6 @@ vehicle_steer_lim_deg: 35.3
 # Unit: s
 vehicle_model_steer_tau : 0.3
 
-# Parameter to switch between passenger car and truck
-# Value type: Measured
-truck: false
-car: true 
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/ssc_interface_wrapper
-lidar_gps_drivers:
-  - /hardware_interface/velodyne_lidar_driver_wrapper
-  - /hardware_interface/novatel_gps_nodelet_wrapper
-camera_drivers:
-  - /hardware_interface/camera
-
 # Vehicle Participation Type corresponding to the Lanelet2 participant type standards. 
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:car"

--- a/development/SubsystemControllerParams.yaml
+++ b/development/SubsystemControllerParams.yaml
@@ -17,6 +17,11 @@ hardware_interface:
       subsystem_namespace: /hardware_interface
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: ['']
+      excluded_namespace_nodes: ['']
+      ros1_required_drivers:
+       - /hardware_interface/controller
+      ros1_camera_drivers:
+      - /hardware_interface/camera
       full_subsystem_required: false
 
 message:

--- a/development/VehicleConfigParams.yaml
+++ b/development/VehicleConfigParams.yaml
@@ -80,20 +80,6 @@ vehicle_steer_lim_deg: 29.2
 # Unit: s
 vehicle_model_steer_tau : 0.3
 
-# Parameter to switch between passenger car and truck
-# Value type: Measured
-truck: false
-car: true
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/controller
-lidar_gps_drivers:
-  - /hardware_interface/lidar
-  - /hardware_interface/gnss
-camera_drivers:
-  - /hardware_interface/camera
-
 # Vehicle Participation Type corresponding to the Lanelet2 participant type standards. 
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:car"

--- a/ford_fusion_sehybrid_2019/SubsystemControllerParams.yaml
+++ b/ford_fusion_sehybrid_2019/SubsystemControllerParams.yaml
@@ -18,6 +18,13 @@ hardware_interface:
       subsystem_namespace: /hardware_interface
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: ['']
+      excluded_namespace_nodes:
+        - /hardware_interface/velodyne_lidar_driver_wrapper
+        - /hardware_interface/novatel_gps_nodelet_wrapper
+      ros1_required_drivers:
+       - /hardware_interface/ssc_interface_wrapper
+      ros1_camera_drivers:
+      - /hardware_interface/camera
       full_subsystem_required: false
 
 message:

--- a/ford_fusion_sehybrid_2019/SubsystemControllerParams.yaml
+++ b/ford_fusion_sehybrid_2019/SubsystemControllerParams.yaml
@@ -20,7 +20,7 @@ hardware_interface:
       unmanaged_required_nodes: ['']
       excluded_namespace_nodes:
         - /hardware_interface/velodyne_lidar_driver_wrapper
-        - /hardware_interface/novatel_gps_nodelet_wrapper
+        - /hardware_interface/carma_novatel_driver_wrapper_node
       ros1_required_drivers:
        - /hardware_interface/ssc_interface_wrapper
       ros1_camera_drivers:

--- a/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
+++ b/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
@@ -80,20 +80,6 @@ vehicle_steer_lim_deg: 32.9
 # Unit: s
 vehicle_model_steer_tau : 0.3
 
-# Parameter to switch between passenger car and truck
-# Value type: Measured
-truck: false
-car: true 
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/ssc_interface_wrapper
-lidar_gps_drivers:
-  - /hardware_interface/velodyne_lidar_driver_wrapper
-  - /hardware_interface/novatel_gps_nodelet_wrapper
-camera_drivers:
-  - /hardware_interface/camera
-
 # Vehicle Participation Type corresponding to the Lanelet2 participant type standards. 
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:car"

--- a/freightliner_cascadia_2012_dot_10002/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_10002/SubsystemControllerParams.yaml
@@ -18,6 +18,14 @@ hardware_interface:
       subsystem_namespace: /hardware_interface
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: ['']
+      excluded_namespace_nodes:
+        - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
+        - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
+        - /hardware_interface/novatel_gps_nodelet_wrapper
+      ros1_required_drivers:
+        - /hardware_interface/ssc_interface_wrapper
+      ros1_camera_drivers:
+      - /hardware_interface/camera
       full_subsystem_required: false
 
 message:

--- a/freightliner_cascadia_2012_dot_10002/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_10002/SubsystemControllerParams.yaml
@@ -21,7 +21,7 @@ hardware_interface:
       excluded_namespace_nodes:
         - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
         - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
-        - /hardware_interface/novatel_gps_nodelet_wrapper
+        - /hardware_interface/carma_novatel_driver_wrapper_node
       ros1_required_drivers:
         - /hardware_interface/ssc_interface_wrapper
       ros1_camera_drivers:

--- a/freightliner_cascadia_2012_dot_10002/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10002/VehicleConfigParams.yaml
@@ -83,21 +83,6 @@ vehicle_steer_lim_deg: 41.5
 # Unit: s
 vehicle_model_steer_tau : 0.3
 
-# Parameter to switch between passenger car and truck
-# Value type: Measured 
-truck: true
-car: false
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/ssc_interface_wrapper
-lidar_gps_drivers:
-  - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
-  - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
-  - /hardware_interface/novatel_gps_nodelet_wrapper
-camera_drivers:
-  - /hardware_interface/camera
-
 # Vehicle Participation Type corresponding to the Lanelet2 participant type standards. 
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:truck"

--- a/freightliner_cascadia_2012_dot_10003/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_10003/SubsystemControllerParams.yaml
@@ -21,7 +21,7 @@ hardware_interface:
       excluded_namespace_nodes:
         - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
         - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
-        - /hardware_interface/novatel_gps_nodelet_wrapper
+        - /hardware_interface/carma_novatel_driver_wrapper_node
       ros1_required_drivers:
         - /hardware_interface/ssc_interface_wrapper
       ros1_camera_drivers:

--- a/freightliner_cascadia_2012_dot_10003/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_10003/SubsystemControllerParams.yaml
@@ -18,6 +18,14 @@ hardware_interface:
       subsystem_namespace: /hardware_interface
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: ['']
+      excluded_namespace_nodes:
+        - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
+        - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
+        - /hardware_interface/novatel_gps_nodelet_wrapper
+      ros1_required_drivers:
+        - /hardware_interface/ssc_interface_wrapper
+      ros1_camera_drivers:
+        - /hardware_interface/camera
       full_subsystem_required: false
 
 message:

--- a/freightliner_cascadia_2012_dot_10003/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10003/VehicleConfigParams.yaml
@@ -83,21 +83,6 @@ vehicle_steer_lim_deg: 41.5
 # Unit: s
 vehicle_model_steer_tau : 0.3
 
-# Parameter to switch between passenger car and truck
-# Value type: Measured 
-truck: true
-car: false
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/ssc_interface_wrapper
-lidar_gps_drivers:
-  - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
-  - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
-  - /hardware_interface/novatel_gps_nodelet_wrapper
-camera_drivers:
-  - /hardware_interface/camera
-
 # Vehicle Participation Type corresponding to the Lanelet2 participant type standards. 
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:truck"

--- a/freightliner_cascadia_2012_dot_10004/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_10004/SubsystemControllerParams.yaml
@@ -21,7 +21,7 @@ hardware_interface:
       excluded_namespace_nodes:
         - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
         - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
-        - /hardware_interface/novatel_gps_nodelet_wrapper
+        - /hardware_interface/carma_novatel_driver_wrapper_node
       ros1_required_drivers:
         - /hardware_interface/ssc_interface_wrapper
       ros1_camera_drivers:

--- a/freightliner_cascadia_2012_dot_10004/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_10004/SubsystemControllerParams.yaml
@@ -18,6 +18,14 @@ hardware_interface:
       subsystem_namespace: /hardware_interface
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: ['']
+      excluded_namespace_nodes:
+        - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
+        - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
+        - /hardware_interface/novatel_gps_nodelet_wrapper
+      ros1_required_drivers:
+        - /hardware_interface/ssc_interface_wrapper
+      ros1_camera_drivers:
+        - /hardware_interface/camera
       full_subsystem_required: false
 
 message:

--- a/freightliner_cascadia_2012_dot_10004/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10004/VehicleConfigParams.yaml
@@ -83,21 +83,6 @@ vehicle_steer_lim_deg: 41.5
 # Unit: s
 vehicle_model_steer_tau : 0.3
 
-# Parameter to switch between passenger car and truck
-# Value type: Measured 
-truck: true
-car: false
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/ssc_interface_wrapper
-lidar_gps_drivers:
-  - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
-  - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
-  - /hardware_interface/novatel_gps_nodelet_wrapper
-camera_drivers:
-  - /hardware_interface/camera
-
 # Vehicle Participation Type corresponding to the Lanelet2 participant type standards. 
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:truck"

--- a/freightliner_cascadia_2012_dot_80550/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_80550/SubsystemControllerParams.yaml
@@ -21,7 +21,7 @@ hardware_interface:
       excluded_namespace_nodes:
         - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
         - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
-        - /hardware_interface/novatel_gps_nodelet_wrapper
+        - /hardware_interface/carma_novatel_driver_wrapper_node
       ros1_required_drivers:
         - /hardware_interface/ssc_interface_wrapper
       ros1_camera_drivers:

--- a/freightliner_cascadia_2012_dot_80550/SubsystemControllerParams.yaml
+++ b/freightliner_cascadia_2012_dot_80550/SubsystemControllerParams.yaml
@@ -18,6 +18,14 @@ hardware_interface:
       subsystem_namespace: /hardware_interface
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: ['']
+      excluded_namespace_nodes:
+        - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
+        - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
+        - /hardware_interface/novatel_gps_nodelet_wrapper
+      ros1_required_drivers:
+        - /hardware_interface/ssc_interface_wrapper
+      ros1_camera_drivers:
+        - /hardware_interface/camera
       full_subsystem_required: false
 
 message:

--- a/freightliner_cascadia_2012_dot_80550/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_80550/VehicleConfigParams.yaml
@@ -83,21 +83,6 @@ vehicle_steer_lim_deg: 41.5
 # Unit: s
 vehicle_model_steer_tau : 0.3
 
-# Parameter to switch between passenger car and truck
-# Value type: Measured 
-truck: true
-car: false
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/ssc_interface_wrapper
-lidar_gps_drivers:
-  - /hardware_interface/velodyne_1/velodyne_lidar_driver_wrapper 
-  - /hardware_interface/velodyne_2/velodyne_lidar_driver_wrapper 
-  - /hardware_interface/novatel_gps_nodelet_wrapper
-camera_drivers:
-  - /hardware_interface/camera
-
 # Vehicle Participation Type corresponding to the Lanelet2 participant type standards. 
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:truck"

--- a/lexus_rx_450h_2019/SubsystemControllerParams.yaml
+++ b/lexus_rx_450h_2019/SubsystemControllerParams.yaml
@@ -21,8 +21,7 @@ hardware_interface:
       excluded_namespace_nodes: # Lidar and GPS drivers are handled by the localization subsystem
         - /hardware_interface/velodyne_lidar_driver_wrapper_node
         - /hardware_interface/carma_novatel_driver_wrapper_node
-      ros1_required_drivers: 
-       - /hardware_interface/controller
+      ros1_required_drivers: ['']
       ros1_camera_drivers:
        - /hardware_interface/camera
       full_subsystem_required: false

--- a/lexus_rx_450h_2019/SubsystemControllerParams.yaml
+++ b/lexus_rx_450h_2019/SubsystemControllerParams.yaml
@@ -18,6 +18,13 @@ hardware_interface:
       subsystem_namespace: /hardware_interface
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: ['']
+      excluded_namespace_nodes: # Lidar and GPS drivers are handled by the localization subsystem
+        - /hardware_interface/velodyne_lidar_driver_wrapper_node
+        - /hardware_interface/carma_novatel_driver_wrapper_node
+      ros1_required_drivers: 
+       - /hardware_interface/controller
+      ros1_camera_drivers:
+       - /hardware_interface/camera
       full_subsystem_required: false
 
 message:

--- a/lexus_rx_450h_2019/VehicleConfigParams.yaml
+++ b/lexus_rx_450h_2019/VehicleConfigParams.yaml
@@ -80,20 +80,6 @@ vehicle_steer_lim_deg: 29.2
 # Unit: s
 vehicle_model_steer_tau : 0.3
 
-# Parameter to switch between passenger car and truck
-# Value type: Measured
-truck: false
-car: true 
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/ssc_interface_wrapper
-lidar_gps_drivers:
-  - /hardware_interface/velodyne_lidar_driver_wrapper
-  - /hardware_interface/novatel_gps_nodelet_wrapper
-camera_drivers:
-  - /hardware_interface/camera
-
 # Vehicle Participation Type corresponding to the Lanelet2 participant type standards. 
 # Used for interpreting traffic rules in world model instances
 vehicle_participant_type: "vehicle:car"

--- a/xil_cloud/SubsystemControllerParams.yaml
+++ b/xil_cloud/SubsystemControllerParams.yaml
@@ -18,6 +18,13 @@ hardware_interface:
       subsystem_namespace: /hardware_interface
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: ['']
+      excluded_namespace_nodes:
+        - /hardware_interface/carla_lidar_driver
+        - /hardware_interface/carla_gnss_driver
+      ros1_required_drivers:
+        - /hardware_interface/carla_drivers
+      ros1_camera_drivers:
+        - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
 
 message:

--- a/xil_cloud/VehicleConfigParams.yaml
+++ b/xil_cloud/VehicleConfigParams.yaml
@@ -81,20 +81,6 @@ vehicle_steer_lim_deg: 29.2
 # Unit: s
 vehicle_model_steer_tau : 0.3
 
-# Parameter to switch between passenger car and truck
-# Value type: Measured
-truck: false
-car: true
-
-# Required drivers for the vehicle to be functional
-required_drivers:
-  - /hardware_interface/carla_driver
-lidar_gps_drivers:
-  - /hardware_interface/carla_lidar_driver
-  - /hardware_interface/carla_gnss_driver
-camera_drivers:
-  - /hardware_interface/carla_camera_driver
-
 # Parameter to enable configurable speed limit
 # Value type: Desired
 config_speed_limit: 20.0


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR adds configuration parameters required for the driver subsystem controller to the vehicle config.
Additional parameters are added to the SubsystemControllerParam to define ros1 nodes that are managed by the Driver Manager. 
Driver specifications are also removed from VehicleConfigParams.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.