### PR TITLE
Updated carma-streets images to develop for xil-cloud docker-compose

### DIFF
--- a/xil_cloud/docker-compose.yml
+++ b/xil_cloud/docker-compose.yml
@@ -338,7 +338,7 @@ services:
     stdin_open: true
     tty: true
   v2xhub:
-    image: usdotfhwaops/v2xhubamd:latest
+    image: usdotfhwaops/v2xhubamd:develop
     container_name: v2xhub
     network_mode: service:db
     restart: always
@@ -364,7 +364,7 @@ services:
       - ./sensor_configurations:/home/V2X-Hub/sensor_configurations/
 
   intersection_model:
-    image: usdotfhwastolcandidate/intersection_model:k900
+    image: usdotfhwastoldev/intersection_model:develop
     container_name: intersection_model
     restart: always
     network_mode: service:zookeeper
@@ -379,7 +379,7 @@ services:
       - ./MAP:/home/carma-streets/intersection_model/MAP
 
   tsc_service:
-    image: usdotfhwastolcandidate/tsc_service:k900-xil
+    image: usdotfhwastoldev/tsc_service:develop
     command: sh -c "/wait && /home/carma-streets/tsc_client_service/build/traffic_signal_controller_service"
     container_name: tsc_service
     restart: always
@@ -396,6 +396,7 @@ services:
       SIMULATION_MODE:  ${SIMULATION_MODE}
       TIME_SYNC_TOPIC: time_sync
       CONFIG_FILE_PATH: /home/carma-streets/tsc_client_service/manifest.json
+      LOGS_DIRECTORY: /home/carma-streets/tsc_client_service/logs/
     volumes:
       - ./tsc_client_service/manifest.json:/home/carma-streets/tsc_client_service/manifest.json
       - ./tsc_client_service/logs/:/home/carma-streets/tsc_client_service/logs/


### PR DESCRIPTION

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Updated CARMA Streets docker images in docker compose to develop and added missing LOGS_DIRECTORY environment variable to tsc_service service description.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix XIL Cloud docker-compose deployment
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Deployed XIL Cloud carma config in AWS cloud instance
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.