### PR TITLE
Revert gps_time param to False for trucks without time synced lidars

### DIFF
--- a/freightliner_cascadia_2012_dot_10002/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10002/drivers.launch.py
@@ -94,7 +94,7 @@ def generate_launch_description():
                             'frame_id' : 'velodyne_1',
                             'device_ip' : '192.168.1.201',
                             'port' : '2368',
-                            'gps_time' : 'True'
+                            'gps_time' : 'False'
                             }.items()
                     ),
                 ]
@@ -109,7 +109,7 @@ def generate_launch_description():
                             'frame_id' : 'velodyne_2',
                             'device_ip' : '192.168.2.201',
                             'port' : '2369',
-                            'gps_time' : 'True'
+                            'gps_time' : 'False'
                             }.items()
                     ),
                 ]

--- a/freightliner_cascadia_2012_dot_10003/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10003/drivers.launch.py
@@ -94,7 +94,7 @@ def generate_launch_description():
                             'frame_id' : 'velodyne_1',
                             'device_ip' : '192.168.1.201',
                             'port' : '2368',
-                            'gps_time' : 'True'
+                            'gps_time' : 'False'
                             }.items()
                     ),
                 ]
@@ -109,7 +109,7 @@ def generate_launch_description():
                             'frame_id' : 'velodyne_2',
                             'device_ip' : '192.168.2.201',
                             'port' : '2369',
-                            'gps_time' : 'True'
+                            'gps_time' : 'False'
                             }.items()
                     ),
                 ]


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR reverts some changes in PR #268 so that the `gps_time` param is set to False when launching the velodyne_lidar_driver_wrapper for freightliners 10002 and 10003, since time synchronization of the lidars using gps time is not yet planned to be completed in those trucks.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-platform/issues/2157
https://usdot-carma.atlassian.net/browse/CF-670

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.