### PR TITLE
Add ScenarioRunner containers to XiL

### DIFF
--- a/xil_cloud/docker-compose.yml
+++ b/xil_cloud/docker-compose.yml
@@ -420,18 +420,18 @@ services:
       - carma-simulation
     command: bash -c "sleep 10;x-terminal-emulator -e python3.8 evc_sumo_bridge.py --asc3app-path '../evcfile/asc3app-application.zip' --traci-ip 172.2.0.2"
 
-  scenario-runner:
-    image: usdotfhwastoldev/carma-scenario-runner:latest
-    container_name: carma-scenario-runner
-    networks:
-      - carma_sim_net
-    depends_on:
-      - carma-simulation
-    entrypoint: >
-      bash -c "sleep 30
-      && python3 scenario_runner.py
-      --scenario MyScenario_1
-      --host 172.2.0.2"
+  # scenario-runner:
+  #   image: usdotfhwastoldev/carma-scenario-runner:develop
+  #   container_name: carma-scenario-runner
+  #   networks:
+  #     - carma_sim_net
+  #   depends_on:
+  #     - carma-simulation
+  #   entrypoint: >
+  #     bash -c "sleep 30
+  #     && python3 scenario_runner.py
+  #     --scenario MyScenario_1
+  #     --host 172.2.0.2"
 
 networks:
   carma_sim_net:

--- a/xil_cloud/docker-compose.yml
+++ b/xil_cloud/docker-compose.yml
@@ -115,7 +115,7 @@ services:
     command: bash -c "sleep 10;
                       export PYTHONPATH=$PYTHONPATH:~/PythonAPI/carla/dist/carla-0.9.10-py3.7-linux-x86_64.egg &&
                       source ~/carma_carla_ws/devel/setup.bash &&
-                      roslaunch carma_carla_agent carma_carla_agent.launch role_name:='carma_1' 
+                      roslaunch carma_carla_agent carma_carla_agent.launch role_name:='carma_1'
                                                                            host:='172.2.0.2'
                                                                            selected_route:='Release_test_case_1'
                                                                            start_delay_in_seconds:='15'
@@ -240,10 +240,10 @@ services:
   #   command: bash -c "sleep 10;
   #                     export PYTHONPATH=$PYTHONPATH:~/PythonAPI/carla/dist/carla-0.9.10-py3.7-linux-x86_64.egg &&
   #                     source ~/carma_carla_ws/devel/setup.bash &&
-  #                     roslaunch carma_carla_agent carma_carla_agent.launch role_name:='carma_2' 
+  #                     roslaunch carma_carla_agent carma_carla_agent.launch role_name:='carma_2'
   #                                                                          host:='172.2.0.2'
-  #                                                                          selected_route:='Release_test_case_2' 
-  #                                                                          start_delay_in_seconds:='15'   
+  #                                                                          selected_route:='Release_test_case_2'
+  #                                                                          start_delay_in_seconds:='15'
   #                                                                          spawn_point:='201.4,-291.5,0,0,0,-90'"
 
   # ns3_adapter_2:
@@ -416,9 +416,22 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ./evc_sumo/evc_sumo_cfg.json:/home/carma/src/resources/evc_sumo_cfg.json
-    depends_on: 
+    depends_on:
       - carma-simulation
     command: bash -c "sleep 10;x-terminal-emulator -e python3.8 evc_sumo_bridge.py --asc3app-path '../evcfile/asc3app-application.zip' --traci-ip 172.2.0.2"
+
+  scenario-runner:
+    image: usdotfhwastoldev/carma-scenario-runner:latest
+    container_name: carma-scenario-runner
+    networks:
+      - carma_sim_net
+    depends_on:
+      - carma-simulation
+    entrypoint: >
+      bash -c "sleep 30
+      && python3 scenario_runner.py
+      --scenario MyScenario_1
+      --host 172.2.0.2"
 
 networks:
   carma_sim_net:
@@ -430,7 +443,7 @@ networks:
     ipam:
       config:
         - subnet: 172.3.0.0/16
-  
+
   # carma_net_2:
   #   ipam:
   #     config:

--- a/xil_cloud_telematics/docker-compose.yml
+++ b/xil_cloud_telematics/docker-compose.yml
@@ -145,6 +145,19 @@ services:
       - NATS_IP=${NATS_IP} # This variable needs to be explictly defined before bringing the container up. NATS_IP referes to the IP of the cloud instance running the telematic server.
     command:  bash -c 'source /ws/install/setup.bash && ros2 launch ros2_nats_bridge ros2_nats_bridge_launch.py'
 
+  scenario-runner:
+    image: usdotfhwastoldev/carma-scenario-runner:latest
+    container_name: carma-scenario-runner
+    networks:
+      - carma_sim_net
+    depends_on:
+      - carma-simulation
+    entrypoint: >
+      bash -c "sleep 30
+      && python3 scenario_runner.py
+      --scenario MyScenario_1
+      --host 172.2.0.2"
+
 networks:
   carma_sim_net:
     ipam:

--- a/xil_cloud_telematics/docker-compose.yml
+++ b/xil_cloud_telematics/docker-compose.yml
@@ -145,18 +145,18 @@ services:
       - NATS_IP=${NATS_IP} # This variable needs to be explictly defined before bringing the container up. NATS_IP referes to the IP of the cloud instance running the telematic server.
     command:  bash -c 'source /ws/install/setup.bash && ros2 launch ros2_nats_bridge ros2_nats_bridge_launch.py'
 
-  scenario-runner:
-    image: usdotfhwastoldev/carma-scenario-runner:latest
-    container_name: carma-scenario-runner
-    networks:
-      - carma_sim_net
-    depends_on:
-      - carma-simulation
-    entrypoint: >
-      bash -c "sleep 30
-      && python3 scenario_runner.py
-      --scenario MyScenario_1
-      --host 172.2.0.2"
+  # scenario-runner:
+  #   image: usdotfhwastoldev/carma-scenario-runner:develop
+  #   container_name: carma-scenario-runner
+  #   networks:
+  #     - carma_sim_net
+  #   depends_on:
+  #     - carma-simulation
+  #   entrypoint: >
+  #     bash -c "sleep 30
+  #     && python3 scenario_runner.py
+  #     --scenario MyScenario_1
+  #     --host 172.2.0.2"
 
 networks:
   carma_sim_net:


### PR DESCRIPTION
# PR Details
## Description

This PR adds the ScenarioRunner container containing the CARMA integration testing scenarios.

## Related Issue

Closes #278 
Closes [CDAR-453](https://usdot-carma.atlassian.net/browse/CDAR-453)

Related to usdot-fhwa-stol/cdasim#167

## Motivation and Context

Needed to have repeatable integration and regression tests.

## How Has This Been Tested?

Manually verified that CDASim launches with the `xil_cloud` configuration.

## Types of changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 

[CDAR-453]: https://usdot-carma.atlassian.net/browse/CDAR-453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ