### PR TITLE
Add source node name to all ROS 2 console log messages

### DIFF
--- a/carla_ground_truth_integration/carma.env
+++ b/carla_ground_truth_integration/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/chrysler_pacifica_ehybrid_s_2019/carma.env
+++ b/chrysler_pacifica_ehybrid_s_2019/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/development/carma.env
+++ b/development/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/ford_fusion_sehybrid_2019/carma.env
+++ b/ford_fusion_sehybrid_2019/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/freightliner_cascadia_2012_dot_10002/carma.env
+++ b/freightliner_cascadia_2012_dot_10002/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/freightliner_cascadia_2012_dot_10003/carma.env
+++ b/freightliner_cascadia_2012_dot_10003/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/freightliner_cascadia_2012_dot_10004/carma.env
+++ b/freightliner_cascadia_2012_dot_10004/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/freightliner_cascadia_2012_dot_80550/carma.env
+++ b/freightliner_cascadia_2012_dot_80550/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/lexus_rx_450h_2019/carma.env
+++ b/lexus_rx_450h_2019/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/traxxas_slash_4x4_platinum_2012/carma.env
+++ b/traxxas_slash_4x4_platinum_2012/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/xil_cloud/carma.env
+++ b/xil_cloud/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 

--- a/xil_cloud_telematics/carma.env
+++ b/xil_cloud_telematics/carma.env
@@ -6,7 +6,7 @@
 ###
 export ROSCONSOLE_CONFIG_FILE="/opt/carma/vehicle/config/carma_rosconsole.conf"
 export ROSCONSOLE_FORMAT='${time} | ${severity} | ${function}:${line} | ${message}' # ROS 1 log formatting
-export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {function_name}:{line_number} | {message}' # ROS2 log formatting
+export RCUTILS_CONSOLE_OUTPUT_FORMAT='{time} | {severity} | {name} | {function_name}:{line_number} | {message}' # ROS2 log formatting
 
 export ROS_LOG_DIR="/opt/carma/logs" # Variable used in both ROS 1 and ROS 2
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This PR updates the `RCUTILS_CONSOLE_OUTPUT_FORMAT` environment variable (which sets the ROS 2 console output format to be used for all log messages) in the `carma.env` file of all carma-configs. Specifically, it adds `{name}`, so that each ROS 2 log message outputted to the console will include the source node's name.

Example console log output before change:
```
platform_ros2                 | [carma_component_container_mt-9] 1701117376.243339196 | INFO | geoReferenceCallback:105 | Extracted Axis: enu
platform_ros2                 | [carma_component_container_mt-9] 1701117376.243666186 | INFO | geoReferenceCallback:109 | Extracted NED in Map Rotation (x,y,z,w) : ( -0.707107, -0.707107, -4.32978e-17, 4.32978e-17
platform_ros2                 | [carma_component_container_mt-24] 1701117376.299148377 | WARN | onTrajPlanTick:693 | Planned trajectory is empty. It will not be published!
platform_ros2                 | [carma_component_container_mt-25] 1701117376.425675634 | INFO | run:36 | Arbitrator spinning in INITIAL state.
```

Same console log output after change:
```
platform_ros2                 | [carma_component_container_mt-9] 1701117376.243339196 | INFO | localization.gnss_to_map_convertor | geoReferenceCallback:105 | Extracted Axis: enu
platform_ros2                 | [carma_component_container_mt-9] 1701117376.243666186 | INFO | localization.gnss_to_map_convertor | geoReferenceCallback:109 | Extracted NED in Map Rotation (x,y,z,w) : ( -0.707107, -0.707107, -4.32978e-17, 4.32978e-17
platform_ros2                 | [carma_component_container_mt-24] 1701117376.299148377 | WARN | plan_delegator | onTrajPlanTick:693 | Planned trajectory is empty. It will not be published!
platform_ros2                 | [carma_component_container_mt-25] 1701117376.425675634 | INFO | guidance.arbitrator | run:36 | Arbitrator spinning in INITIAL state.
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
TODO

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested locally with development config.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.