### PR TITLE
use_sim_time

### DIFF
--- a/trb2024/carma_docker.launch.py
+++ b/trb2024/carma_docker.launch.py
@@ -22,6 +22,18 @@ from launch.substitutions import LaunchConfiguration
 
 from carma_ros2_utils.launch.generate_log_levels import generate_log_levels
 import os
+import yaml
+def is_using_sim_time(vehicle_config_param_file):
+      # Open vehicle config params file to process various rosbag settings
+    with open(vehicle_config_param_file, 'r') as f:
+        vehicle_config_params = yaml.safe_load(f)
+
+        if "use_sim_time" in vehicle_config_params:
+            if vehicle_config_params["use_sim_time"] == True:
+                print('Returning True')
+                return 'True'
+    print('Returning False')
+    return 'False'
 
 def generate_launch_description():
     """
@@ -29,8 +41,10 @@ def generate_launch_description():
     """
 
     # Parse the log config file and convert it to an environment variable
-    config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'carma_rosconsole.conf')
-    logging_env_var = SetEnvironmentVariable('CARMA_ROS_LOGGING_CONFIG', generate_log_levels(config_file_path))
+    log_config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'carma_rosconsole.conf')
+    vehicle_config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'VehicleConfigParams.yaml')
+
+    logging_env_var = SetEnvironmentVariable('CARMA_ROS_LOGGING_CONFIG', generate_log_levels(log_config_file_path))
 
     # Declare the vehicle_calibration_dir launch argument
     vehicle_calibration_dir = LaunchConfiguration('vehicle_calibration_dir')
@@ -43,11 +57,10 @@ def generate_launch_description():
     declare_vehicle_config_dir_arg = DeclareLaunchArgument(
         name = 'vehicle_config_dir', default_value = '/opt/carma/vehicle/config', description = "Path to vehicle configuration directory"
     )
-    
-    # Declare the simuation_mode argument
-    simulation_mode = LaunchConfiguration('simulation_mode')
-    declare_simulation_mode = DeclareLaunchArgument(name='simulation_mode', default_value = 'True', description = 'True if CARMA Platform is launched with CARLA Simulator')
 
+    # Declare the simuation_mode argument
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    declare_use_sim_time = DeclareLaunchArgument(name='use_sim_time', default_value = is_using_sim_time(vehicle_config_file_path), description = 'True if CARMA Platform is launched with CARLA Simulator')
 
     # Declare launch arguments for points_map_loader
     load_type = LaunchConfiguration('load_type')
@@ -121,7 +134,7 @@ def generate_launch_description():
             'area' : area,
             'arealist_path' : arealist_path,
             'vector_map_file' : vector_map_file,
-            'simulation_mode' : simulation_mode
+            'use_sim_time' : use_sim_time
             }.items()
     )
 
@@ -139,6 +152,6 @@ def generate_launch_description():
         declare_area,
         declare_arealist_path,
         declare_vector_map_file,
-        declare_simulation_mode,
+        declare_use_sim_time,
         carma_src_launch
     ])

--- a/xil_cloud/carma_docker.launch.py
+++ b/xil_cloud/carma_docker.launch.py
@@ -22,6 +22,18 @@ from launch.substitutions import LaunchConfiguration
 
 from carma_ros2_utils.launch.generate_log_levels import generate_log_levels
 import os
+import yaml
+def is_using_sim_time(vehicle_config_param_file):
+      # Open vehicle config params file to process various rosbag settings
+    with open(vehicle_config_param_file, 'r') as f:
+        vehicle_config_params = yaml.safe_load(f)
+
+        if "use_sim_time" in vehicle_config_params:
+            if vehicle_config_params["use_sim_time"] == True:
+                print('Returning True')
+                return 'True'
+    print('Returning False')
+    return 'False'
 
 def generate_launch_description():
     """
@@ -29,8 +41,10 @@ def generate_launch_description():
     """
 
     # Parse the log config file and convert it to an environment variable
-    config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'carma_rosconsole.conf')
-    logging_env_var = SetEnvironmentVariable('CARMA_ROS_LOGGING_CONFIG', generate_log_levels(config_file_path))
+    log_config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'carma_rosconsole.conf')
+    vehicle_config_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'VehicleConfigParams.yaml')
+
+    logging_env_var = SetEnvironmentVariable('CARMA_ROS_LOGGING_CONFIG', generate_log_levels(log_config_file_path))
 
     # Declare the vehicle_calibration_dir launch argument
     vehicle_calibration_dir = LaunchConfiguration('vehicle_calibration_dir')
@@ -43,11 +57,10 @@ def generate_launch_description():
     declare_vehicle_config_dir_arg = DeclareLaunchArgument(
         name = 'vehicle_config_dir', default_value = '/opt/carma/vehicle/config', description = "Path to vehicle configuration directory"
     )
-    
-    # Declare the simuation_mode argument
-    simulation_mode = LaunchConfiguration('simulation_mode')
-    declare_simulation_mode = DeclareLaunchArgument(name='simulation_mode', default_value = 'True', description = 'True if CARMA Platform is launched with CARLA Simulator')
 
+    # Declare the simuation_mode argument
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    declare_use_sim_time = DeclareLaunchArgument(name='use_sim_time', default_value = is_using_sim_time(vehicle_config_file_path), description = 'True if CARMA Platform is launched with CARLA Simulator')
 
     # Declare launch arguments for points_map_loader
     load_type = LaunchConfiguration('load_type')
@@ -108,8 +121,8 @@ def generate_launch_description():
     # Declare is_ros2_tracing_enabled
     is_ros2_tracing_enabled = LaunchConfiguration('is_ros2_tracing_enabled')
     declare_is_ros2_tracing_enabled = DeclareLaunchArgument(
-        name='is_ros2_tracing_enabled', 
-        default_value = 'False', 
+        name='is_ros2_tracing_enabled',
+        default_value = 'False',
         description = 'True if user wants ROS 2 Tracing logs to be generated from CARMA Platform'
     )
 
@@ -129,7 +142,7 @@ def generate_launch_description():
             'area' : area,
             'arealist_path' : arealist_path,
             'vector_map_file' : vector_map_file,
-            'simulation_mode' : simulation_mode
+            'use_sim_time' : use_sim_time
             }.items()
     )
 
@@ -147,7 +160,7 @@ def generate_launch_description():
         declare_area,
         declare_arealist_path,
         declare_vector_map_file,
-        declare_simulation_mode,
+        declare_use_sim_time,
         declare_is_ros2_tracing_enabled,
         carma_src_launch
     ])


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR allows the carma-platform nodes to use sim_time. Most of the nodes in carma-platform are carma_lifecycle_node which can directly load parameters from VehicleConfigParams.yaml whic his where the use_sim_time is set. 

However, some of the nodes such as system_controller and subsystem_controller are just normal rclcpp Node, so ros__parameters syntax is required. Therefore, this launch file directly extracted the boolean and passes it through the launch files.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.