### PR TITLE
CDAR-754: Adding volume for CarlaCDASimAdapter log files

### DIFF
--- a/ail_vru_uc1_scenario/docker-compose.yml
+++ b/ail_vru_uc1_scenario/docker-compose.yml
@@ -287,6 +287,8 @@ services:
       - LOAD_CARLA_EGG=True
       - CARLA_VERSION=0.9.10
       - CARLA_EGG_DIR=/home/CarlaCDASimAdapter/
+    volumes:
+      - ./carla-sensor-lib/logs/:/home/CarlaCDASimAdapter/logs/
     command: bash -c "sleep 15;
       python3 -u /home/CarlaCDASimAdapter/src/CarlaCDASimAdapter.py --carla-host 172.2.0.2 --xmlrpc-server-host 172.2.0.5  --sensor-config-file ./config/simulated_sensor_config.yaml --noise-model-config-file ./config/noise_model_config.yaml"
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
**NOTE: Requires log file fixes in PR (https://github.com/usdot-fhwa-stol/carla-sensor-lib/pull/14) to actually result in log file creation**
<!--- Describe your changes in detail -->
Added volume to carla-sensor-lib image to map to default log directory of CarlaCDASimAdapter 
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Add file logging to make debugging easier
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
CDASim deployment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.