### PR TITLE
Remove transient_local quality of service settings for system_alert topic for ros1_bridge

### DIFF
--- a/ail_vru_uc1_scenario/bridge.yml
+++ b/ail_vru_uc1_scenario/bridge.yml
@@ -26,7 +26,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -71,28 +71,21 @@ topics:
     topic: /environment/external_object_predictions
     type: carma_perception_msgs/msg/ExternalObjectList
     queue_size: 1
-  
   -
     topic: /hardware_interface/comms/outbound_binary_msg
     type: carma_driver_msgs/msg/ByteArray
     queue_size: 100
     direction: 2to1
-  
   -
     topic: /hardware_interface/comms/inbound_binary_msg
     type: carma_driver_msgs/msg/ByteArray
     queue_size: 100
     direction: 1to2
-
   -
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/carla_ground_truth_integration/bridge.yml
+++ b/carla_ground_truth_integration/bridge.yml
@@ -23,7 +23,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -72,11 +72,7 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/chrysler_pacifica_ehybrid_s_2019/bridge.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/bridge.yml
@@ -1,7 +1,7 @@
-# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the 
+# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the
 # ROS2 migration is underway.
-# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
-#       this file allows for certain topics to be pre-configured with specified QoS settings. 
+# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but
+#       this file allows for certain topics to be pre-configured with specified QoS settings.
 topics:
   -
     topic: /environment/lanelet2_map_viz
@@ -23,7 +23,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -68,11 +68,7 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/development/bridge.yml
+++ b/development/bridge.yml
@@ -1,7 +1,7 @@
-# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the 
+# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the
 # ROS2 migration is underway.
-# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
-#       this file allows for certain topics to be pre-configured with specified QoS settings. 
+# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but
+#       this file allows for certain topics to be pre-configured with specified QoS settings.
 topics:
   -
     topic: /environment/lanelet2_map_viz
@@ -23,7 +23,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -68,11 +68,7 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/ford_fusion_sehybrid_2019/bridge.yml
+++ b/ford_fusion_sehybrid_2019/bridge.yml
@@ -1,7 +1,7 @@
-# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the 
+# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the
 # ROS2 migration is underway.
-# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
-#       this file allows for certain topics to be pre-configured with specified QoS settings. 
+# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but
+#       this file allows for certain topics to be pre-configured with specified QoS settings.
 topics:
   -
     topic: /environment/lanelet2_map_viz
@@ -23,7 +23,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -68,11 +68,7 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/freightliner_cascadia_2012_dot_10002/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10002/bridge.yml
@@ -1,7 +1,7 @@
-# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the 
+# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the
 # ROS2 migration is underway.
-# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
-#       this file allows for certain topics to be pre-configured with specified QoS settings. 
+# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but
+#       this file allows for certain topics to be pre-configured with specified QoS settings.
 topics:
   -
     topic: /environment/lanelet2_map_viz
@@ -23,7 +23,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -68,11 +68,7 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/freightliner_cascadia_2012_dot_10003/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10003/bridge.yml
@@ -1,7 +1,7 @@
-# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the 
+# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the
 # ROS2 migration is underway.
-# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
-#       this file allows for certain topics to be pre-configured with specified QoS settings. 
+# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but
+#       this file allows for certain topics to be pre-configured with specified QoS settings.
 topics:
   -
     topic: /environment/lanelet2_map_viz
@@ -23,7 +23,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -68,11 +68,7 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/freightliner_cascadia_2012_dot_10004/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10004/bridge.yml
@@ -1,7 +1,7 @@
-# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the 
+# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the
 # ROS2 migration is underway.
-# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
-#       this file allows for certain topics to be pre-configured with specified QoS settings. 
+# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but
+#       this file allows for certain topics to be pre-configured with specified QoS settings.
 topics:
   -
     topic: /environment/lanelet2_map_viz
@@ -23,7 +23,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -68,11 +68,7 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/freightliner_cascadia_2012_dot_80550/bridge.yml
+++ b/freightliner_cascadia_2012_dot_80550/bridge.yml
@@ -1,7 +1,7 @@
-# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the 
+# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the
 # ROS2 migration is underway.
-# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
-#       this file allows for certain topics to be pre-configured with specified QoS settings. 
+# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but
+#       this file allows for certain topics to be pre-configured with specified QoS settings.
 topics:
   -
     topic: /environment/lanelet2_map_viz
@@ -23,7 +23,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -68,11 +68,7 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/lexus_rx_450h_2019/bridge.yml
+++ b/lexus_rx_450h_2019/bridge.yml
@@ -1,7 +1,7 @@
-# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the 
+# This file contains explicit topic mappings between ROS1 and ROS2 portions of CARMA Platform while the
 # ROS2 migration is underway.
-# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
-#       this file allows for certain topics to be pre-configured with specified QoS settings. 
+# NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but
+#       this file allows for certain topics to be pre-configured with specified QoS settings.
 topics:
   -
     topic: /environment/lanelet2_map_viz
@@ -23,7 +23,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -68,11 +68,7 @@ topics:
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/xil_cloud/bridge.yml
+++ b/xil_cloud/bridge.yml
@@ -34,7 +34,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -79,28 +79,23 @@ topics:
     topic: /environment/external_object_predictions
     type: carma_perception_msgs/msg/ExternalObjectList
     queue_size: 1
-  
+
   -
     topic: /hardware_interface/comms/outbound_binary_msg
     type: carma_driver_msgs/msg/ByteArray
     queue_size: 100
     direction: 2to1
-  
+
   -
     topic: /hardware_interface/comms/inbound_binary_msg
     type: carma_driver_msgs/msg/ByteArray
     queue_size: 100
     direction: 1to2
-
   -
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1

--- a/xil_cloud_telematics/bridge.yml
+++ b/xil_cloud_telematics/bridge.yml
@@ -34,7 +34,7 @@ topics:
       depth: 1
       durability: transient_local
   -
-    topic: /environment/base_map  
+    topic: /environment/base_map
     type: autoware_lanelet2_msgs/msg/MapBin
     queue_size: 1
     direction: 2to1
@@ -79,28 +79,21 @@ topics:
     topic: /environment/external_object_predictions
     type: carma_perception_msgs/msg/ExternalObjectList
     queue_size: 1
-  
   -
     topic: /hardware_interface/comms/outbound_binary_msg
     type: carma_driver_msgs/msg/ByteArray
     queue_size: 100
     direction: 2to1
-  
   -
     topic: /hardware_interface/comms/inbound_binary_msg
     type: carma_driver_msgs/msg/ByteArray
     queue_size: 100
     direction: 1to2
-
   -
     topic: /system_alert
     type: carma_msgs/msg/SystemAlert
     queue_size: 5
-    qos:
-      history: keep_last
-      depth: 5
-      durability: transient_local
-  - 
+  -
     topic: /localization/vehicle/odom
     type: nav_msgs/msg/Odometry
     queue_size: 1


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
In PR #211, the `bridge.yml` file of each carma-config was updated so that the `ros1_bridge1` publisher to /system_alert had quality of service (qos) configured to transient local. This is because a message was published on the ROS 1 side of CARMA Platform to indicate "drivers are ready" to the rest of the system, and late-joining subscribers dropped this message without this qos update. 

This qos setting for the /system_alert publisher in `ros1_bridge` is being removed for the following reasons:
- There is no longer a /system_alert publication on the ROS 1 side to indicate "drivers are ready", so this message doesn't need to be persisted for late-joining subscribers.
- No /system_alert publishers on the ROS 2 side have the 'transient local' qos setting; instead, they have the volatile qos setting. When a subscriber first receives messages from a publisher on a topic, it takes account of that publisher's qos setting, and the subscriber will not receive any messages from other publishers to that topic that have a different qos setting. In the case of /system_alert, if a ROS 2 subscriber first receives a message from the `ros1_bridge` publisher to /system_alert (with qos transient_local), it will never receive messages from a /system_alert publisher with qos set to volatile (all other /system_alert publishers in CARMA Platform at this time).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[CARMA Platform Issue #2287](https://github.com/usdot-fhwa-stol/carma-platform/issues/2287)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Resolves the above issue.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on the Silver Truck with its config and locally running the development config. Prior to change, the Web UI did not receive any messages published to /system_alert from nodes other than `ros1_bridge`; after the change, it does receive messages published to /system_alert from other nodes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.