### PR TITLE
CAR-6028 Fix Lexus config to use released CARMA Web UI image

### DIFF
--- a/lexus_rx_450h_2019/docker-compose-background.yml
+++ b/lexus_rx_450h_2019/docker-compose-background.yml
@@ -1,11 +1,11 @@
 #  Copyright (C) 2018-2021 LEIDOS.
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
 #  the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 #  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -17,13 +17,13 @@ version: '2'
 
 services:
   web-ui:
-    image: usdotfhwastol/carma-web-ui:lavida
+    image: usdotfhwastol/carma-web-ui:carma-system-4.5.0
     network_mode: host
     container_name: web-ui
     environment:
       - ROS_IP=192.168.0.100
-    volumes_from: 
+    volumes_from:
       - container:carma-config:ro
-    volumes: 
-      - /var/run/docker.sock:/var/run/docker.sock 
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     restart: always


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
This is a hotfix to `master` (and its current associated carma-system-4.5.0 tag) to fix an issue within the `lexus_rx_450h_2019` carma-config to use `usdotfhwastol/carma-web-ui:carma-system-4.5.0` rather than `usdotfhwastol/carma-web-ui:lavida`.

This update was originally intended to be a part of PR #337.

Related JIRA ticket: [CAR-6028](https://usdot-carma.atlassian.net/browse/CAR-6028)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Released carma-configs (under the `master` branch or `carma-system-*` tags) should leverage released DockerHub images.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and on the Blue Lexus.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

[CAR-6028]: https://usdot-carma.atlassian.net/browse/CAR-6028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ