### PR TITLE
Remove truck_inspection from carma config

### DIFF
--- a/freightliner_cascadia_2012_dot_10002/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10002/docker-compose.yml
@@ -82,23 +82,6 @@ services:
       - /opt/carma/yolo:/opt/carma/yolo
     command: bash -c 'wait-for-it.sh localhost:11311 -- rosparam load /opt/carma/vehicle/config/bridge.yml && source ~/.base-image/workspace/install/setup.bash && ros2 run ros1_bridge dynamic_bridge --multi-threads'
     
-  truck-inspection:
-    image: ${DOCKER_ORG}/carma-platform:${DOCKER_TAG}
-    network_mode: host
-    container_name: carma-truck-inspection
-    volumes_from:
-      - container:carma-config:ro
-    volumes:
-      - /opt/carma/logs:/opt/carma/logs
-      - /opt/carma/.ros:/home/carma/.ros
-      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
-      - /opt/carma/yolo:/opt/carma/yolo
-      - /opt/carma/maps:/opt/carma/maps
-      - /opt/carma/routes:/opt/carma/routes
-    environment:
-      - ROS_IP=192.168.88.10
-    command: wait-for-it.sh localhost:11311 -- roslaunch truck_inspection_client truck_inspection_client.launch truck_inspection_client_param_file:=/opt/carma/vehicle/calibration/truck_inspection_client/parameters.yaml
-
   lightbar-driver:
     image: ${DOCKER_ORG}/carma-lightbar-driver:${DOCKER_TAG}
     network_mode: host

--- a/freightliner_cascadia_2012_dot_10003/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10003/docker-compose.yml
@@ -82,23 +82,6 @@ services:
       - /opt/carma/yolo:/opt/carma/yolo
     command: bash -c 'wait-for-it.sh localhost:11311 -- rosparam load /opt/carma/vehicle/config/bridge.yml && source ~/.base-image/workspace/install/setup.bash && ros2 run ros1_bridge dynamic_bridge --multi-threads'
     
-  truck-inspection:
-    image: ${DOCKER_ORG}/carma-platform:${DOCKER_TAG}
-    network_mode: host
-    container_name: carma-truck-inspection
-    volumes_from:
-      - container:carma-config:ro
-    volumes:
-      - /opt/carma/logs:/opt/carma/logs
-      - /opt/carma/.ros:/home/carma/.ros
-      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
-      - /opt/carma/yolo:/opt/carma/yolo
-      - /opt/carma/maps:/opt/carma/maps
-      - /opt/carma/routes:/opt/carma/routes
-    environment:
-      - ROS_IP=192.168.88.10
-    command: wait-for-it.sh localhost:11311 -- roslaunch truck_inspection_client truck_inspection_client.launch truck_inspection_client_param_file:=/opt/carma/vehicle/calibration/truck_inspection_client/parameters.yaml
-
   lightbar-driver:
     image: ${DOCKER_ORG}/carma-lightbar-driver:${DOCKER_TAG}
     network_mode: host

--- a/freightliner_cascadia_2012_dot_10004/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_10004/docker-compose.yml
@@ -82,23 +82,6 @@ services:
       - /opt/carma/yolo:/opt/carma/yolo
     command: bash -c 'wait-for-it.sh localhost:11311 -- rosparam load /opt/carma/vehicle/config/bridge.yml && source ~/.base-image/workspace/install/setup.bash && ros2 run ros1_bridge dynamic_bridge --multi-threads'
     
-  truck-inspection:
-    image: ${DOCKER_ORG}/carma-platform:${DOCKER_TAG}
-    network_mode: host
-    container_name: carma-truck-inspection
-    volumes_from:
-      - container:carma-config:ro
-    volumes:
-      - /opt/carma/logs:/opt/carma/logs
-      - /opt/carma/.ros:/home/carma/.ros
-      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
-      - /opt/carma/yolo:/opt/carma/yolo
-      - /opt/carma/maps:/opt/carma/maps
-      - /opt/carma/routes:/opt/carma/routes
-    environment:
-      - ROS_IP=192.168.88.10
-    command: wait-for-it.sh localhost:11311 -- roslaunch truck_inspection_client truck_inspection_client.launch truck_inspection_client_param_file:=/opt/carma/vehicle/calibration/truck_inspection_client/parameters.yaml
-
   lightbar-driver:
     image: ${DOCKER_ORG}/carma-lightbar-driver:${DOCKER_TAG}
     network_mode: host

--- a/freightliner_cascadia_2012_dot_80550/docker-compose.yml
+++ b/freightliner_cascadia_2012_dot_80550/docker-compose.yml
@@ -82,23 +82,6 @@ services:
       - /opt/carma/yolo:/opt/carma/yolo
     command: bash -c 'wait-for-it.sh localhost:11311 -- rosparam load /opt/carma/vehicle/config/bridge.yml && source ~/.base-image/workspace/install/setup.bash && ros2 run ros1_bridge dynamic_bridge --multi-threads'
     
-  truck-inspection:
-    image: ${DOCKER_ORG}/carma-platform:${DOCKER_TAG}
-    network_mode: host
-    container_name: carma-truck-inspection
-    volumes_from:
-      - container:carma-config:ro
-    volumes:
-      - /opt/carma/logs:/opt/carma/logs
-      - /opt/carma/.ros:/home/carma/.ros
-      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
-      - /opt/carma/yolo:/opt/carma/yolo
-      - /opt/carma/maps:/opt/carma/maps
-      - /opt/carma/routes:/opt/carma/routes
-    environment:
-      - ROS_IP=192.168.88.10
-    command: wait-for-it.sh localhost:11311 -- roslaunch truck_inspection_client truck_inspection_client.launch truck_inspection_client_param_file:=/opt/carma/vehicle/calibration/truck_inspection_client/parameters.yaml
-
   lightbar-driver:
     image: ${DOCKER_ORG}/carma-lightbar-driver:${DOCKER_TAG}
     network_mode: host


### PR DESCRIPTION
# PR Details
## Description

This PR removes the unused `truck_inspection_client` from the freightliner carma configs.

Related PRs:
- [carma-platform #2396](https://github.com/usdot-fhwa-stol/carma-platform/pull/2396)
- [carma-vehicle-calibration #126](https://github.com/usdot-fhwa-stol/carma-vehicle-calibration/pull/126)

## Related Issue

[CAR-5919](https://usdot-carma.atlassian.net/browse/CAR-5919)

## Motivation and Context

The `truck_inspection_client` node in `carma-platform` has remained unused for multiple years and is not a part of future planned work. Since this node is still in ROS 1 Noetic, a decision has been made to remove it rather than port it to ROS 2.

## How Has This Been Tested?

A docker image was built using a freightliner `carma-config` with the `truck_inspection_client` package removed. CARMA platform successfully launches on a development laptop.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

[CAR-5919]: https://usdot-carma.atlassian.net/browse/CAR-5919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ