### PR TITLE
Fix/no carma cloud time sync log

### DIFF
--- a/xil_carma_cloud/cdasim_config/carmacloudvol/log4j2.properties
+++ b/xil_carma_cloud/cdasim_config/carmacloudvol/log4j2.properties
@@ -1,0 +1,18 @@
+status = warn
+monitorInterval = 300
+
+appender.rolling.type = RollingFile
+appender.rolling.name = LogToRollingFile
+appender.rolling.fileName = /opt/tomcat/logs/carmacloud.log
+appender.rolling.filePattern = /opt/tomcat/logs/carmacloud-%d{yyyyMMdd}.log.gz
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = [%-5level %d{HH:mm:ss.SSS} [%c{1}] - %msg%n
+appender.rolling.policies.type = Policies
+appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
+appender.rolling.policies.time.interval = 1
+appender.rolling.policies.time.modulate = false
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 366
+
+rootLogger.level = debug
+rootLogger.appenderRef.stdout.ref = LogToRollingFile

--- a/xil_carma_cloud/cdasim_config/carmacloudvol/web.xml
+++ b/xil_carma_cloud/cdasim_config/carmacloudvol/web.xml
@@ -1,0 +1,345 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+
+<display-name>CARMAcloud</display-name>
+<welcome-file-list>
+ <welcome-file>login.html</welcome-file>
+</welcome-file-list>
+
+<welcome-file-list>
+ <welcome-file>login.html</welcome-file>
+</welcome-file-list>
+
+<servlet>
+ <servlet-name>RegHub</servlet-name>
+ <servlet-class>cc.ws.RegHub</servlet-class>
+
+ <load-on-startup>-1</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>RegHub</servlet-name>
+ <url-pattern>/carmacloud/v2xhub/*</url-pattern>
+</servlet-mapping>
+
+
+<servlet>
+ <servlet-name>SimFederate</servlet-name>
+ <servlet-class>cc.ws.SimFederate</servlet-class>
+ 
+ <init-param>
+  <description>OPTIONAL: Logical flag to specify real world time or simulation time mode. Not present or false indicates real world time mode.</description>
+  <param-name>simulation</param-name>
+  <param-value>true</param-value>
+ </init-param> 
+  
+ <init-param>
+  <description>OPTIONAL: Required when simulation is true. Network address for simulation ambassador.</description>
+  <param-name>ambassador</param-name>
+  <param-value>172.2.0.2</param-value>
+ </init-param> 
+ 
+ <init-param>
+  <description>OPTIONAL: Required when simulation is true. Simulation identifier for this CARMA Cloud instance.</description>
+  <param-name>id</param-name>
+  <param-value>carma-cloud-sim1</param-value>
+ </init-param> 
+ 
+ <init-param>
+  <description>OPTIONAL: Required when simulation is true. URL where ambassador sends time sync messages.</description>
+  <param-name>url</param-name>
+  <param-value>http://172.2.0.47:8080/carmacloud/simulation</param-value>
+ </init-param> 
+  
+ <load-on-startup>1</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>SimFederate</servlet-name>
+ <url-pattern>/carmacloud/simulation/*</url-pattern>
+</servlet-mapping>
+
+
+<servlet>
+ <servlet-name>SessMgr</servlet-name>
+ <servlet-class>cc.ws.SessMgr</servlet-class>
+
+ <init-param>
+  <description>OPTIONAL: session timeout in milliseconds</description>
+  <param-name>timeout</param-name>
+  <param-value>18000000</param-value>
+ </init-param>
+
+ <load-on-startup>2</load-on-startup>
+</servlet>
+
+
+<servlet>
+ <servlet-name>UserMgr</servlet-name>
+ <servlet-class>cc.ws.UserMgr</servlet-class>
+
+ <init-param>
+  <description>REQUIRED: path to user credential file</description>
+  <param-name>pwdfile</param-name>
+  <param-value>/opt/tomcat/webapps/carmacloud/user.csv</param-value>
+ </init-param>
+
+ <load-on-startup>3</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>UserMgr</servlet-name>
+ <url-pattern>/api/auth/*</url-pattern>
+</servlet-mapping>
+
+
+<servlet>
+ <servlet-name>CtrlTiles</servlet-name>
+ <servlet-class>cc.ws.CtrlTiles</servlet-class>
+
+ <init-param>
+  <description>REQUIRED: path to .xodr file containing road defintions</description>
+  <param-name>xodrdir</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/xodr/</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: </description>
+  <param-name>linearcdir</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/linearcs/</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: format string for tiled data filenames</description>
+  <param-name>tileddataformat</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/td/%d/ctrls_%d_%d_%d.bin</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: format string for tiled data filenames</description>
+  <param-name>ctrldir</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/traf_ctrls</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: zoom level used to create tiled data</description>
+  <param-name>zoom</param-name>
+  <param-value>17</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: zoom level used to create tiled data</description>
+  <param-name>explodestep</param-name>
+  <param-value>0.06</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: zoom level used to create tiled data</description>
+  <param-name>combinetol</param-name>
+  <param-value>0.1</param-value>
+ </init-param>
+ 
+ <init-param>
+  <description>REQUIRED: file path for units</description>
+  <param-name>units</param-name>
+  <param-value>/opt/tomcat/webapps/carmacloud/units.csv</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: file path for units</description>
+  <param-name>units</param-name>
+  <param-value>/opt/tomcat/webapps/carmacloud/units.csv</param-value>
+ </init-param>
+
+ <load-on-startup>4</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>CtrlTiles</servlet-name>
+ <url-pattern>/api/ctrl/*</url-pattern>
+</servlet-mapping>
+
+
+<servlet>
+ <servlet-name>TcmReq</servlet-name>
+ <servlet-class>cc.ws.TcmReqServlet</servlet-class>
+
+ <init-param>
+  <description>OPTIONAL: number of cm desired inbetween each point in xml</description>
+  <param-name>xmldist</param-name>
+  <param-value>1500</param-value>
+ </init-param>
+
+ <load-on-startup>4</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>TcmReq</servlet-name>
+ <url-pattern>/carmacloud/tcmreq/*</url-pattern>
+</servlet-mapping>
+
+
+<servlet>
+ <servlet-name>TcmAck</servlet-name>
+ <servlet-class>cc.ws.TcmAckServlet</servlet-class>
+
+ <load-on-startup>4</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>TcmAck</servlet-name>
+ <url-pattern>/carmacloud/tcmack/*</url-pattern>
+</servlet-mapping>
+
+
+<servlet>
+ <servlet-name>GeoLanes</servlet-name>
+ <servlet-class>cc.ws.GeoLanes</servlet-class>
+
+ <init-param>
+  <param-name>dir</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/geolanes</param-value>
+ </init-param>
+
+ <load-on-startup>4</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>GeoLanes</servlet-name>
+ <url-pattern>/api/geolanes/*</url-pattern>
+</servlet-mapping>
+
+
+<servlet>
+ <servlet-name>WxPoly</servlet-name>
+ <servlet-class>cc.ws.WxPoly</servlet-class>
+
+ <load-on-startup>4</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>WxPoly</servlet-name>
+ <url-pattern>/api/wxpoly/*</url-pattern>
+</servlet-mapping>
+
+<servlet>
+ <servlet-name>ValidateXodrTiles</servlet-name>
+ <servlet-class>cc.ws.ValidateXodrTiles</servlet-class>
+
+ <init-param>
+  <description>REQUIRED: path to .xodr file containing road defintions</description>
+  <param-name>xodrdir</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/validate/xodr/</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: </description>
+  <param-name>linearcdir</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/validate/linearcs/</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: format string for tiled data filenames</description>
+  <param-name>tileddataformat</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/validate/td/%d/ctrls_%d_%d_%d.bin</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: format string for tiled data filenames</description>
+  <param-name>ctrldir</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/validate/traf_ctrls</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: zoom level used to create tiled data</description>
+  <param-name>zoom</param-name>
+  <param-value>17</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: zoom level used to create tiled data</description>
+  <param-name>explodestep</param-name>
+  <param-value>0.06</param-value>
+ </init-param>
+
+ <init-param>
+  <description>REQUIRED: zoom level used to create tiled data</description>
+  <param-name>combinetol</param-name>
+  <param-value>0.1</param-value>
+ </init-param>
+
+ <load-on-startup>4</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>ValidateXodrTiles</servlet-name>
+ <url-pattern>/api/vctrl/*</url-pattern>
+</servlet-mapping>
+
+ 
+<servlet>
+ <servlet-name>IHP</servlet-name>
+ <servlet-class>cc.ihp.IHP</servlet-class>
+
+ <init-param>
+  <param-name>pfile</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/ihp/parameters.csv</param-value>
+ </init-param>
+
+ <init-param>
+  <param-name>cfile</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/ihp/corridor.csv</param-value>
+ </init-param>
+
+ <init-param>
+  <param-name>dfile</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/ihp/detectors.json</param-value>
+ </init-param>
+
+ <init-param>
+  <param-name>basedir</param-name>
+  <param-value>/opt/tomcat/work/carmacloud/ihp/</param-value>
+ </init-param>
+
+ <load-on-startup>4</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>IHP</servlet-name>
+ <url-pattern>/api/ihp/*</url-pattern>
+</servlet-mapping>
+
+
+<servlet>
+ <servlet-name>RSU</servlet-name>
+ <servlet-class>cc.ws.RSUServlet</servlet-class>
+ 
+  <init-param>
+  <description>REQUIRED: Duration to store the received BSM request. Unit of second</description>
+  <param-name>bsmReqDuration</param-name>
+  <param-value>5</param-value>
+ </init-param> 
+ 
+ <init-param>
+  <description>REQUIRED: Periodically checking if the BSM is stored longer than the specified duration. Unit of second</description>
+  <param-name>bsmReqCheckPeriod</param-name>
+  <param-value>2</param-value>
+ </init-param> 
+  
+ <init-param>
+  <description>REQUIRED: Bounding box radius in meters</description>
+  <param-name>boundingBoxRadius</param-name>
+  <param-value>20</param-value>
+ </init-param> 
+  
+ <load-on-startup>4</load-on-startup>
+</servlet>
+
+<servlet-mapping>
+ <servlet-name>RSU</servlet-name>
+ <url-pattern>/carmacloud/rsu/*</url-pattern>
+</servlet-mapping>
+
+</web-app>

--- a/xil_carma_cloud/docker-compose.yml
+++ b/xil_carma_cloud/docker-compose.yml
@@ -324,6 +324,8 @@ services:
     volumes:
       - ./carmacloudvol/logs:/opt/tomcat/logs
       - ./carmacloudvol/work:/opt/tomcat/work
+      - ./carmacloudvol/web.xml:/opt/tomcat/webapps/carmacloud/ROOT/WEB-INF/web.xml
+      - ./carmacloudvol/log4j2.properties:/opt/tomcat/webapps/carmacloud/WEB-INF/classes/log4j2.properties
     command: bash -c "/opt/tomcat/bin/catalina.sh run"
 
   zookeeper:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

CARMA Cloud can't show up the time sync message sent from CDASim correctly due to the log level config not setting up properly. This PR add two logs file which were used during the integration test for checking the CARMA Cloud time sync logs

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.