### PR TITLE
revert cdasim subsystem controller config to platform 4.5.0

### DIFF
--- a/xil_carma_cloud/SubsystemControllerParams.yaml
+++ b/xil_carma_cloud/SubsystemControllerParams.yaml
@@ -26,8 +26,6 @@ hardware_interface:
       ros1_camera_drivers:
         - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
-      startup_duration: 60
-
 
 message:
   v2x_controller:
@@ -49,7 +47,7 @@ guidance:
         - /guidance/plugins/route_following_plugin
         - /guidance/plugins/pure_pursuit_wrapper
         - /guidance/plugins/inlanecruising_plugin
-      #  - /guidance/plugins/cooperative_lanechange
+        - /guidance/plugins/cooperative_lanechange
       auto_activated_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/intersection_transit_maneuvering

--- a/xil_carma_cloud/SubsystemControllerParams.yaml
+++ b/xil_carma_cloud/SubsystemControllerParams.yaml
@@ -21,7 +21,10 @@ hardware_interface:
       excluded_namespace_nodes:
         - /hardware_interface/carla_lidar_driver
         - /hardware_interface/carla_gnss_driver
-      ros1_ssc_driver_name: /hardware_interface/carla_driver
+      ros1_required_drivers:
+        - /hardware_interface/carla_driver
+      ros1_camera_drivers:
+        - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
       startup_duration: 60
 
@@ -46,17 +49,32 @@ guidance:
         - /guidance/plugins/route_following_plugin
         - /guidance/plugins/pure_pursuit_wrapper
         - /guidance/plugins/inlanecruising_plugin
-        - /guidance/plugins/cooperative_lanechange
-      auto_activated_plugins: # TODO: Current logic requires that at most one control be activated at a time. This will be addressed under CAR-6064. https://usdot-carma.atlassian.net/browse/CAR-6064
+      #  - /guidance/plugins/cooperative_lanechange
+      auto_activated_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/intersection_transit_maneuvering
         - /guidance/plugins/light_controlled_intersection_tactical_plugin
         - /guidance/plugins/stop_and_wait_plugin
         - /guidance/plugins/sci_strategic_plugin
         - /guidance/plugins/stop_controlled_intersection_tactical_plugin
+        - /guidance/plugins/platoon_control_ihp
         - /guidance/plugins/platoon_strategic_ihp_node
         - /guidance/plugins/platooning_tactical_plugin_node
         - /guidance/plugins/yield_plugin
+      ros2_initial_plugins:
+        - /guidance/plugins/inlanecruising_plugin
+        - /guidance/plugins/platoon_strategic_ihp_node
+        - /guidance/plugins/stop_and_wait_plugin
+        - /guidance/plugins/route_following_plugin
+        - /guidance/plugins/platooning_tactical_plugin_node
+        - /guidance/plugins/cooperative_lanechange
+        - /guidance/plugins/light_controlled_intersection_tactical_plugin
+        - /guidance/plugins/sci_strategic_plugin
+        - /guidance/plugins/stop_controlled_intersection_tactical_plugin
+        - /guidance/plugins/yield_plugin
+        - /guidance/plugins/pure_pursuit_wrapper
+        - /guidance/plugins/lci_strategic_plugin
+        - /guidance/plugins/intersection_transit_maneuvering
 
 
 localization:

--- a/xil_carma_cloud/SubsystemControllerParams.yaml
+++ b/xil_carma_cloud/SubsystemControllerParams.yaml
@@ -26,6 +26,8 @@ hardware_interface:
       ros1_camera_drivers:
         - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
+      startup_duration: 60
+      required_driver_timeout: 30000.0 #ROS1 bridge dropping message depending on computer
 
 message:
   v2x_controller:
@@ -47,7 +49,6 @@ guidance:
         - /guidance/plugins/route_following_plugin
         - /guidance/plugins/pure_pursuit_wrapper
         - /guidance/plugins/inlanecruising_plugin
-        - /guidance/plugins/cooperative_lanechange
       auto_activated_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/intersection_transit_maneuvering

--- a/xil_cloud_telematics/SubsystemControllerParams.yaml
+++ b/xil_cloud_telematics/SubsystemControllerParams.yaml
@@ -26,8 +26,6 @@ hardware_interface:
       ros1_camera_drivers:
         - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
-      startup_duration: 60
-
 
 message:
   v2x_controller:
@@ -49,7 +47,7 @@ guidance:
         - /guidance/plugins/route_following_plugin
         - /guidance/plugins/pure_pursuit_wrapper
         - /guidance/plugins/inlanecruising_plugin
-      #  - /guidance/plugins/cooperative_lanechange
+        - /guidance/plugins/cooperative_lanechange
       auto_activated_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/intersection_transit_maneuvering

--- a/xil_cloud_telematics/SubsystemControllerParams.yaml
+++ b/xil_cloud_telematics/SubsystemControllerParams.yaml
@@ -21,10 +21,13 @@ hardware_interface:
       excluded_namespace_nodes:
         - /hardware_interface/carla_lidar_driver
         - /hardware_interface/carla_gnss_driver
-      ros1_ssc_driver_name: /hardware_interface/carla_driver
+      ros1_required_drivers:
+        - /hardware_interface/carla_driver
+      ros1_camera_drivers:
+        - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
       startup_duration: 60
-      ros1_ssc_driver_timeout: 30000.0 #ROS1 bridge dropping message depending on computer
+
 
 message:
   v2x_controller:
@@ -42,10 +45,11 @@ guidance:
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: [''] # TODO add the controller driver once it is integrated with ROS2
       full_subsystem_required: true
-      required_plugins: # TODO: Current logic requires that at most one control be activated at a time. This will be addressed under CAR-6064. https://usdot-carma.atlassian.net/browse/CAR-6064
+      required_plugins:
         - /guidance/plugins/route_following_plugin
         - /guidance/plugins/pure_pursuit_wrapper
         - /guidance/plugins/inlanecruising_plugin
+      #  - /guidance/plugins/cooperative_lanechange
       auto_activated_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/intersection_transit_maneuvering
@@ -53,9 +57,24 @@ guidance:
         - /guidance/plugins/stop_and_wait_plugin
         - /guidance/plugins/sci_strategic_plugin
         - /guidance/plugins/stop_controlled_intersection_tactical_plugin
+        - /guidance/plugins/platoon_control_ihp
         - /guidance/plugins/platoon_strategic_ihp_node
         - /guidance/plugins/platooning_tactical_plugin_node
         - /guidance/plugins/yield_plugin
+      ros2_initial_plugins:
+        - /guidance/plugins/inlanecruising_plugin
+        - /guidance/plugins/platoon_strategic_ihp_node
+        - /guidance/plugins/stop_and_wait_plugin
+        - /guidance/plugins/route_following_plugin
+        - /guidance/plugins/platooning_tactical_plugin_node
+        - /guidance/plugins/cooperative_lanechange
+        - /guidance/plugins/light_controlled_intersection_tactical_plugin
+        - /guidance/plugins/sci_strategic_plugin
+        - /guidance/plugins/stop_controlled_intersection_tactical_plugin
+        - /guidance/plugins/yield_plugin
+        - /guidance/plugins/pure_pursuit_wrapper
+        - /guidance/plugins/lci_strategic_plugin
+        - /guidance/plugins/intersection_transit_maneuvering
 
 
 localization:

--- a/xil_cloud_telematics/SubsystemControllerParams.yaml
+++ b/xil_cloud_telematics/SubsystemControllerParams.yaml
@@ -26,6 +26,8 @@ hardware_interface:
       ros1_camera_drivers:
         - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
+      startup_duration: 60
+      required_driver_timeout: 30000.0 #ROS1 bridge dropping message depending on computer
 
 message:
   v2x_controller:
@@ -47,7 +49,6 @@ guidance:
         - /guidance/plugins/route_following_plugin
         - /guidance/plugins/pure_pursuit_wrapper
         - /guidance/plugins/inlanecruising_plugin
-        - /guidance/plugins/cooperative_lanechange
       auto_activated_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/intersection_transit_maneuvering

--- a/xil_vru_uc1_scenario/SubsystemControllerParams.yaml
+++ b/xil_vru_uc1_scenario/SubsystemControllerParams.yaml
@@ -26,8 +26,6 @@ hardware_interface:
       ros1_camera_drivers:
         - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
-      startup_duration: 60
-
 
 message:
   v2x_controller:
@@ -49,7 +47,7 @@ guidance:
         - /guidance/plugins/route_following_plugin
         - /guidance/plugins/pure_pursuit_wrapper
         - /guidance/plugins/inlanecruising_plugin
-      #  - /guidance/plugins/cooperative_lanechange
+        - /guidance/plugins/cooperative_lanechange
       auto_activated_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/intersection_transit_maneuvering

--- a/xil_vru_uc1_scenario/SubsystemControllerParams.yaml
+++ b/xil_vru_uc1_scenario/SubsystemControllerParams.yaml
@@ -21,10 +21,13 @@ hardware_interface:
       excluded_namespace_nodes:
         - /hardware_interface/carla_lidar_driver
         - /hardware_interface/carla_gnss_driver
-      ros1_ssc_driver_name: /hardware_interface/carla_driver
+      ros1_required_drivers:
+        - /hardware_interface/carla_driver
+      ros1_camera_drivers:
+        - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
       startup_duration: 60
-      ros1_ssc_driver_timeout: 30000.0 #ROS1 bridge dropping message depending on computer
+
 
 message:
   v2x_controller:
@@ -42,10 +45,11 @@ guidance:
       required_subsystem_nodes: ['']
       unmanaged_required_nodes: [''] # TODO add the controller driver once it is integrated with ROS2
       full_subsystem_required: true
-      required_plugins: # TODO: Current logic requires that at most one control be activated at a time. This will be addressed under CAR-6064. https://usdot-carma.atlassian.net/browse/CAR-6064
+      required_plugins:
         - /guidance/plugins/route_following_plugin
         - /guidance/plugins/pure_pursuit_wrapper
         - /guidance/plugins/inlanecruising_plugin
+      #  - /guidance/plugins/cooperative_lanechange
       auto_activated_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/intersection_transit_maneuvering
@@ -53,9 +57,24 @@ guidance:
         - /guidance/plugins/stop_and_wait_plugin
         - /guidance/plugins/sci_strategic_plugin
         - /guidance/plugins/stop_controlled_intersection_tactical_plugin
+        - /guidance/plugins/platoon_control_ihp
         - /guidance/plugins/platoon_strategic_ihp_node
         - /guidance/plugins/platooning_tactical_plugin_node
         - /guidance/plugins/yield_plugin
+      ros2_initial_plugins:
+        - /guidance/plugins/inlanecruising_plugin
+        - /guidance/plugins/platoon_strategic_ihp_node
+        - /guidance/plugins/stop_and_wait_plugin
+        - /guidance/plugins/route_following_plugin
+        - /guidance/plugins/platooning_tactical_plugin_node
+        - /guidance/plugins/cooperative_lanechange
+        - /guidance/plugins/light_controlled_intersection_tactical_plugin
+        - /guidance/plugins/sci_strategic_plugin
+        - /guidance/plugins/stop_controlled_intersection_tactical_plugin
+        - /guidance/plugins/yield_plugin
+        - /guidance/plugins/pure_pursuit_wrapper
+        - /guidance/plugins/lci_strategic_plugin
+        - /guidance/plugins/intersection_transit_maneuvering
 
 
 localization:

--- a/xil_vru_uc1_scenario/SubsystemControllerParams.yaml
+++ b/xil_vru_uc1_scenario/SubsystemControllerParams.yaml
@@ -26,6 +26,8 @@ hardware_interface:
       ros1_camera_drivers:
         - /hardware_interface/carla_camera_driver
       full_subsystem_required: false
+      startup_duration: 60
+      required_driver_timeout: 30000.0 #ROS1 bridge dropping message depending on computer
 
 message:
   v2x_controller:
@@ -47,7 +49,6 @@ guidance:
         - /guidance/plugins/route_following_plugin
         - /guidance/plugins/pure_pursuit_wrapper
         - /guidance/plugins/inlanecruising_plugin
-        - /guidance/plugins/cooperative_lanechange
       auto_activated_plugins:
         - /guidance/plugins/lci_strategic_plugin
         - /guidance/plugins/intersection_transit_maneuvering


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Reverts Subsystemcontroller yaml for cdasim configs to required values for CARMA Platform tag carma-system-4.5.0, since these configs are pointing to that version of carma-platform.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Integration tested on sim pc with cdasim deployment.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.