### PR TITLE
remove launch args from drivers.launch.py

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/drivers.launch.py
+++ b/chrysler_pacifica_ehybrid_s_2019/drivers.launch.py
@@ -119,7 +119,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/chrysler_pacifica_ehybrid_s_2019/drivers.launch.py
+++ b/chrysler_pacifica_ehybrid_s_2019/drivers.launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('dsrc_driver'), '/launch/dsrc_driver.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('dsrc_driver', env_log_levels),
                     }.items()
             ),
@@ -86,7 +86,7 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('velodyne_lidar_driver_wrapper'), '/launch/velodyne_lidar_driver_wrapper_launch.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('velodyne_lidar_driver_wrapper', env_log_levels),
                     'device_ip' : '192.168.1.201',
                     'port' : '2368'
@@ -101,7 +101,7 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('carma_novatel_driver_wrapper'), '/launch/carma-novatel-driver-wrapper-launch.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('carma_novatel_driver_wrapper', env_log_levels),
                     'ip_addr' : '192.168.88.29',
                     'port' : '2000',
@@ -117,10 +117,8 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'ip_addr' : '192.168.88.28',
-                    'port' : '80',
                     'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),

--- a/ford_fusion_sehybrid_2019/drivers.launch.py
+++ b/ford_fusion_sehybrid_2019/drivers.launch.py
@@ -119,7 +119,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/ford_fusion_sehybrid_2019/drivers.launch.py
+++ b/ford_fusion_sehybrid_2019/drivers.launch.py
@@ -73,7 +73,7 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('dsrc_driver'), '/launch/dsrc_driver.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('dsrc_driver', env_log_levels),
                     }.items()
             ),
@@ -86,7 +86,7 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('velodyne_lidar_driver_wrapper'), '/launch/velodyne_lidar_driver_wrapper_launch.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('velodyne_lidar_driver_wrapper', env_log_levels),
                     'device_ip' : '192.168.1.201',
                     'port' : '2368'
@@ -101,7 +101,7 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('carma_novatel_driver_wrapper'), '/launch/carma-novatel-driver-wrapper-launch.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('carma_novatel_driver_wrapper', env_log_levels),
                     'ip_addr' : '192.168.88.29',
                     'port' : '2000',
@@ -117,10 +117,8 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'ip_addr' : '192.168.88.28',
-                    'port' : '80',
                     'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),

--- a/freightliner_cascadia_2012_dot_10002/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10002/drivers.launch.py
@@ -151,8 +151,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'ip_addr' : '192.168.88.28',
-                    'port' : '80',
                     'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),

--- a/freightliner_cascadia_2012_dot_10002/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10002/drivers.launch.py
@@ -151,7 +151,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/freightliner_cascadia_2012_dot_10003/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10003/drivers.launch.py
@@ -151,8 +151,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'ip_addr' : '192.168.88.28',
-                    'port' : '80',
                     'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),

--- a/freightliner_cascadia_2012_dot_10003/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10003/drivers.launch.py
@@ -151,7 +151,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/freightliner_cascadia_2012_dot_10004/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10004/drivers.launch.py
@@ -151,8 +151,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'ip_addr' : '192.168.88.28',
-                    'port' : '80',
                     'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),

--- a/freightliner_cascadia_2012_dot_10004/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_10004/drivers.launch.py
@@ -151,7 +151,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/freightliner_cascadia_2012_dot_80550/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_80550/drivers.launch.py
@@ -151,8 +151,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'ip_addr' : '192.168.88.28',
-                    'port' : '80',
                     'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),

--- a/freightliner_cascadia_2012_dot_80550/drivers.launch.py
+++ b/freightliner_cascadia_2012_dot_80550/drivers.launch.py
@@ -151,7 +151,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]

--- a/lexus_rx_450h_2019/drivers.launch.py
+++ b/lexus_rx_450h_2019/drivers.launch.py
@@ -74,7 +74,7 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('dsrc_driver'), '/launch/dsrc_driver.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('dsrc_driver', env_log_levels),
                     }.items()
             ),
@@ -88,7 +88,7 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('ssc_interface_wrapper_ros2'), '/launch/ssc_pacmod_driver.launch.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('ssc_interface_wrapper_ros2', env_log_levels),
                     'vehicle_calibration_dir' : vehicle_calibration_dir,
                     'ssc_package_name' : 'ssc_pm_lexus',
@@ -97,14 +97,14 @@ def generate_launch_description():
             ),
         ]
     )
-    
+
     lidar_group = GroupAction(
         condition=IfCondition(PythonExpression(["'velodyne_lidar_driver_wrapper' in '", drivers, "'.split()"])),
         actions=[
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('velodyne_lidar_driver_wrapper'), '/launch/velodyne_lidar_driver_wrapper_launch.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('velodyne_lidar_driver_wrapper', env_log_levels),
                     'device_ip' : '192.168.1.201',
                     'port' : '2368'
@@ -119,7 +119,7 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('carma_novatel_driver_wrapper'), '/launch/carma-novatel-driver-wrapper-launch.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('carma_novatel_driver_wrapper', env_log_levels),
                     'ip_addr' : '192.168.74.10',
                     'port' : '2000',
@@ -135,10 +135,8 @@ def generate_launch_description():
             PushRosNamespace(EnvironmentVariable('CARMA_INTR_NS', default_value='hardware_interface')),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
-                launch_arguments = { 
+                launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'ip_addr' : '192.168.88.28',
-                    'port' : '80',
                     'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),

--- a/lexus_rx_450h_2019/drivers.launch.py
+++ b/lexus_rx_450h_2019/drivers.launch.py
@@ -137,7 +137,6 @@ def generate_launch_description():
                 PythonLaunchDescriptionSource([ FindPackageShare('lightbar_driver'), '/launch/lightbar_driver_node_launch.py']),
                 launch_arguments = {
                     'log_level' : GetLogLevel('lightbar_driver', env_log_levels),
-                    'vehicle_calibration_dir' : vehicle_calibration_dir,
                     }.items()
             ),
         ]


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Launch arguments for Lightbar driver are removed from drivers.launch.py since config parameters are added to the driver node.
https://github.com/usdot-fhwa-stol/carma-lightbar-driver/pull/77
## Related Issue

https://usdot-carma.atlassian.net/browse/ARC-166

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.