### PR TITLE
Add ROS1 controller topics to bridge.yml

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/bridge.yml
+++ b/chrysler_pacifica_ehybrid_s_2019/bridge.yml
@@ -3,6 +3,10 @@
 # NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
 #       this file allows for certain topics to be pre-configured with specified QoS settings. 
 topics:
+  - topic: /hardware_interface/steering_report
+    type: raptor_dbw_msgs/msg/SteeringReport
+    queue_size: 1
+    direction: 1to2
   -
     topic: /environment/lanelet2_map_viz
     type: visualization_msgs/msg/MarkerArray

--- a/ford_fusion_sehybrid_2019/bridge.yml
+++ b/ford_fusion_sehybrid_2019/bridge.yml
@@ -3,6 +3,10 @@
 # NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
 #       this file allows for certain topics to be pre-configured with specified QoS settings. 
 topics:
+  - topic: /hardware_interface/ds_fusion/steering_report
+    type: dbw_mkz_msgs/msg/SteeringReport
+    queue_size: 1
+    direction: 1to2
   -
     topic: /environment/lanelet2_map_viz
     type: visualization_msgs/msg/MarkerArray

--- a/freightliner_cascadia_2012_dot_10002/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10002/bridge.yml
@@ -3,6 +3,10 @@
 # NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
 #       this file allows for certain topics to be pre-configured with specified QoS settings. 
 topics:
+  - topic: /hardware_interface/as/pacmod/parsed_tx/steer_rpt
+    type: pacmod3_msgs/msg/SystemRptFloat
+    queue_size: 1
+    direction: 1to2
   -
     topic: /environment/lanelet2_map_viz
     type: visualization_msgs/msg/MarkerArray

--- a/freightliner_cascadia_2012_dot_10003/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10003/bridge.yml
@@ -3,6 +3,10 @@
 # NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
 #       this file allows for certain topics to be pre-configured with specified QoS settings. 
 topics:
+  - topic: /hardware_interface/as/pacmod/parsed_tx/steer_rpt
+    type: pacmod3_msgs/msg/SystemRptFloat
+    queue_size: 1
+    direction: 1to2
   -
     topic: /environment/lanelet2_map_viz
     type: visualization_msgs/msg/MarkerArray

--- a/freightliner_cascadia_2012_dot_10004/bridge.yml
+++ b/freightliner_cascadia_2012_dot_10004/bridge.yml
@@ -3,6 +3,10 @@
 # NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
 #       this file allows for certain topics to be pre-configured with specified QoS settings. 
 topics:
+  - topic: /hardware_interface/as/pacmod/parsed_tx/steer_rpt
+    type: pacmod3_msgs/msg/SystemRptFloat
+    queue_size: 1
+    direction: 1to2
   -
     topic: /environment/lanelet2_map_viz
     type: visualization_msgs/msg/MarkerArray

--- a/freightliner_cascadia_2012_dot_80550/bridge.yml
+++ b/freightliner_cascadia_2012_dot_80550/bridge.yml
@@ -3,6 +3,10 @@
 # NOTE: A custom dynamic_bridge is used in CARMA Platform which will automatically connect topics and services, but 
 #       this file allows for certain topics to be pre-configured with specified QoS settings. 
 topics:
+  - topic: /hardware_interface/as/pacmod/parsed_tx/steer_rpt
+    type: pacmod3_msgs/msg/SystemRptFloat
+    queue_size: 1
+    direction: 1to2
   -
     topic: /environment/lanelet2_map_viz
     type: visualization_msgs/msg/MarkerArray


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds ROS1 controller topics to the bridge.yml so that steering_wheel_analysis can be made on ROS2 mcap data.

<!--- Describe your changes in detail -->

## Related Issue
ARC-254
https://github.com/usdot-fhwa-stol/carma-analytics-fotda/pull/101
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Controller analysis scripts
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in Black Pacifica and locally exchanging data
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.