### PR TITLE
Enable external object recording for mcap

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
+++ b/chrysler_pacifica_ehybrid_s_2019/VehicleConfigParams.yaml
@@ -112,8 +112,6 @@ excluded_default_topics:
   - (.*)/scan
   - (.*)/compressed(.*)
   - /environment/base_map
-  - /environment/external_object_predictions
-  - /environment/external_objects_viz
   - /environment/map_filtered_points
   - /environment/points_no_ground
   - /environment/points_in_base_link

--- a/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
+++ b/ford_fusion_sehybrid_2019/VehicleConfigParams.yaml
@@ -112,8 +112,6 @@ excluded_default_topics:
   - (.*)/scan
   - (.*)/compressed(.*)
   - /environment/base_map
-  - /environment/external_object_predictions
-  - /environment/external_objects_viz
   - /environment/map_filtered_points
   - /environment/points_no_ground
   - /environment/points_in_base_link

--- a/freightliner_cascadia_2012_dot_10002/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10002/VehicleConfigParams.yaml
@@ -115,8 +115,6 @@ excluded_default_topics:
   - (.*)/scan
   - (.*)/compressed(.*)
   - /environment/base_map
-  - /environment/external_object_predictions
-  - /environment/external_objects_viz
   - /environment/map_filtered_points
   - /environment/points_no_ground
   - /environment/points_in_base_link

--- a/freightliner_cascadia_2012_dot_10003/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10003/VehicleConfigParams.yaml
@@ -115,8 +115,6 @@ excluded_default_topics:
   - (.*)/scan
   - (.*)/compressed(.*)
   - /environment/base_map
-  - /environment/external_object_predictions
-  - /environment/external_objects_viz
   - /environment/map_filtered_points
   - /environment/points_no_ground
   - /environment/points_in_base_link

--- a/freightliner_cascadia_2012_dot_10004/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_10004/VehicleConfigParams.yaml
@@ -115,8 +115,6 @@ excluded_default_topics:
   - (.*)/scan
   - (.*)/compressed(.*)
   - /environment/base_map
-  - /environment/external_object_predictions
-  - /environment/external_objects_viz
   - /environment/map_filtered_points
   - /environment/points_no_ground
   - /environment/points_in_base_link

--- a/freightliner_cascadia_2012_dot_80550/VehicleConfigParams.yaml
+++ b/freightliner_cascadia_2012_dot_80550/VehicleConfigParams.yaml
@@ -115,8 +115,6 @@ excluded_default_topics:
   - (.*)/scan
   - (.*)/compressed(.*)
   - /environment/base_map
-  - /environment/external_object_predictions
-  - /environment/external_objects_viz
   - /environment/map_filtered_points
   - /environment/points_no_ground
   - /environment/points_in_base_link

--- a/lexus_rx_450h_2019/VehicleConfigParams.yaml
+++ b/lexus_rx_450h_2019/VehicleConfigParams.yaml
@@ -112,8 +112,6 @@ excluded_default_topics:
   - (.*)/scan
   - (.*)/compressed(.*)
   - /environment/base_map
-  - /environment/external_object_predictions
-  - /environment/external_objects_viz
   - /environment/map_filtered_points
   - /environment/points_no_ground
   - /environment/points_in_base_link


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
As there have been a lot of testing with CP, we need to debug using the external objects related topics more. 
However, it isn't enabled for recording with mcap by default and making it hard to debug.

<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
NA
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
CP Integration testing 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.