### PR TITLE
Add GitHub Actions Docker builds for Carma-config

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,72 @@
+name: Docker build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build development image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./development/
+          push: false
+
+      - name: Build ford_fusion_sehybrid_2019 image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./ford_fusion_sehybrid_2019/
+          push: false
+
+      - name: Build lexus_rx_450h_2019 image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./lexus_rx_450h_2019/
+          push: false
+
+      - name: Build chrysler_pacifica_ehybrid_s_2019 image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./chrysler_pacifica_ehybrid_s_2019/
+          push: false
+
+      - name: Build freightliner_cascadia_2012_dot_10002 image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./freightliner_cascadia_2012_dot_10002/
+          push: false
+
+      - name: Build freightliner_cascadia_2012_dot_10003 image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./freightliner_cascadia_2012_dot_10003/
+          push: false
+
+      - name: Build freightliner_cascadia_2012_dot_10004 image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./freightliner_cascadia_2012_dot_10004/
+          push: false
+
+      - name: Build freightliner_cascadia_2012_dot_80550 image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./freightliner_cascadia_2012_dot_80550/
+          push: false

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -57,14 +57,11 @@ jobs:
           push: true
           tags: ${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}/carma-config:${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}-ford-fusion-sehybrid-2019
           build-args: |
-            GIT_BRANCH=${{ github.ref_name }}
-            DOCKER_TAG=${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}
-            DOCKER_ORG=${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}
             BUILD_DATE=${{ steps.docker-image-metadata.outputs.build_date }}
             VCS_REF=${{ steps.docker-image-metadata.outputs.vcs_ref }}
             VERSION=${{ steps.docker-image-metadata.outputs.version }}
 
-      - name: Build and Push lexus_rx_450h_2019
+      - name: Build and Push lexus_rx_450h_2019 Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./lexus_rx_450h_2019/
@@ -76,7 +73,7 @@ jobs:
             VERSION=${{ steps.docker-image-metadata.outputs.version }}
 
 
-      - name: Build and chrysler_pacifica_ehybrid_s_2019 Docker Image
+      - name: Build and Push chrysler_pacifica_ehybrid_s_2019 Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./chrysler_pacifica_ehybrid_s_2019/

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,132 @@
+name: Docker Hub build
+on:
+  push:
+    branches:
+      - develop
+      - master
+      - "release/*"
+    tags:
+      - "carma-system-*"
+jobs:
+  determine_docker_org_and_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      docker_organization: ${{ steps.docker-org-and-tag.outputs.docker_organization }}
+      docker_image_tag: ${{ steps.docker-org-and-tag.outputs.docker_image_tag }}
+    steps:
+      - id: docker-org-and-tag
+        uses: usdot-fhwa-stol/actions/docker-org-and-tag@main
+
+  docker:
+    needs: determine_docker_org_and_tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get Docker Image Metadata
+        shell: bash
+        id: docker-image-metadata
+        run: |
+          echo "version=$(./docker/get-system-version.sh)" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "vcs_ref=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push development Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./development/
+          push: true
+          tags: ${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}/carma-config:${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}-development
+          build-args: |
+            BUILD_DATE=${{ steps.docker-image-metadata.outputs.build_date }}
+            VCS_REF=${{ steps.docker-image-metadata.outputs.vcs_ref }}
+            VERSION=${{ steps.docker-image-metadata.outputs.version }}
+
+      - name: Build and Push ford_fusion_sehybrid_2019 Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./ford_fusion_sehybrid_2019/
+          push: true
+          tags: ${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}/carma-config:${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}-ford-fusion-sehybrid-2019
+          build-args: |
+            GIT_BRANCH=${{ github.ref_name }}
+            DOCKER_TAG=${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}
+            DOCKER_ORG=${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}
+            BUILD_DATE=${{ steps.docker-image-metadata.outputs.build_date }}
+            VCS_REF=${{ steps.docker-image-metadata.outputs.vcs_ref }}
+            VERSION=${{ steps.docker-image-metadata.outputs.version }}
+
+      - name: Build and Push lexus_rx_450h_2019
+        uses: docker/build-push-action@v5
+        with:
+          context: ./lexus_rx_450h_2019/
+          push: true
+          tags: ${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}/carma-config:${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}-lexus-rx-450h-2019
+          build-args: |
+            BUILD_DATE=${{ steps.docker-image-metadata.outputs.build_date }}
+            VCS_REF=${{ steps.docker-image-metadata.outputs.vcs_ref }}
+            VERSION=${{ steps.docker-image-metadata.outputs.version }}
+
+
+      - name: Build and chrysler_pacifica_ehybrid_s_2019 Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./chrysler_pacifica_ehybrid_s_2019/
+          push: true
+          tags: ${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}/carma-config:${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}-chrysler-pacifica-ehybrid-s-2019
+          build-args: |
+            BUILD_DATE=${{ steps.docker-image-metadata.outputs.build_date }}
+            VCS_REF=${{ steps.docker-image-metadata.outputs.vcs_ref }}
+            VERSION=${{ steps.docker-image-metadata.outputs.version }}
+
+      - name: Build and Push freightliner_cascadia_2012_dot_10002 Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./freightliner_cascadia_2012_dot_10002/
+          push: true
+          tags: ${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}/carma-config:${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}-freightliner-cascadia-2012-dot-10002
+          build-args: |
+            BUILD_DATE=${{ steps.docker-image-metadata.outputs.build_date }}
+            VCS_REF=${{ steps.docker-image-metadata.outputs.vcs_ref }}
+            VERSION=${{ steps.docker-image-metadata.outputs.version }}
+
+      - name: Build and Push freightliner_cascadia_2012_dot_10003 Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./freightliner_cascadia_2012_dot_10003/
+          push: true
+          tags: ${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}/carma-config:${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}-freightliner-cascadia-2012-dot-10003
+          build-args: |
+            BUILD_DATE=${{ steps.docker-image-metadata.outputs.build_date }}
+            VCS_REF=${{ steps.docker-image-metadata.outputs.vcs_ref }}
+            VERSION=${{ steps.docker-image-metadata.outputs.version }}
+
+      - name: Build and Push freightliner_cascadia_2012_dot_10004 Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./freightliner_cascadia_2012_dot_10004/
+          push: true
+          tags: ${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}/carma-config:${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}-freightliner-cascadia-2012-dot-10004
+          build-args: |
+            BUILD_DATE=${{ steps.docker-image-metadata.outputs.build_date }}
+            VCS_REF=${{ steps.docker-image-metadata.outputs.vcs_ref }}
+            VERSION=${{ steps.docker-image-metadata.outputs.version }}
+    
+      - name: Build and Push freightliner_cascadia_2012_dot_80550 Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./freightliner_cascadia_2012_dot_80550/
+          push: true
+          tags: ${{ needs.determine_docker_org_and_tag.outputs.docker_organization }}/carma-config:${{ needs.determine_docker_org_and_tag.outputs.docker_image_tag }}-freightliner-cascadia-2012-dot-80550
+          build-args: |
+            BUILD_DATE=${{ steps.docker-image-metadata.outputs.build_date }}
+            VCS_REF=${{ steps.docker-image-metadata.outputs.vcs_ref }}
+            VERSION=${{ steps.docker-image-metadata.outputs.version }}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR Replaces Docker Hub automated builds with GitHub Actions for carma-config. This includes docker.yml to build-only workflow on PR's and dockerhub.yml push workflow to build/push images to the correct Docker orgs based on branch/tag.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.