### PR TITLE
Add default global parameter values

### DIFF
--- a/chrysler_pacifica_ehybrid_s_2019/GlobalParamsOverride.yaml
+++ b/chrysler_pacifica_ehybrid_s_2019/GlobalParamsOverride.yaml
@@ -7,34 +7,33 @@
 # use the default values in the respective package's yaml files
 # NOTE: Be sure to include the node name here, which may not be same as the package name
 # NOTE: SubsystemControllers has its own override file for easier organization
-# localization:
-#   localization_manager:
-#     ros__parameters:
-#       localization_mode: 4
-#       x_offset: 0.0
-#       y_offset: 0.0
+localization:
+  localization_manager:
+    ros__parameters:
+      localization_mode: 5
+      x_offset: 2.2
+      y_offset: -2.1
 
-# # Nested namespace example for guidance and plugins
-# guidance:
-#   plan_delegator:
-#     ros__parameters:
-#       max_traj_generation_reattempt: 50
-#   plugins:
-#     lci_strategic_plugin:
-#       ros__parameters:
-#         min_approach_distance: 20.0
-#         trajectory_smoothing_activation_distance: 40.0
-#         minimum_speed: 5.0
-#         algo_minimum_speed: 0.894
-#     inlanecruising_plugin:
-#       ros__parameters:
-#         default_downsample_ratio: 4
-#         turn_downsample_ratio: 4
-#         minimum_speed: 5.0
+# Nested namespace example for guidance and plugins
+guidance:
+  plan_delegator:
+    ros__parameters:
+      max_traj_generation_reattempt: 1000
+  plugins:
+    lci_strategic_plugin:
+      ros__parameters:
+        min_approach_distance: 30.0
+        trajectory_smoothing_activation_distance: 140.0
+        algo_minimum_speed:  4.4704
+    inlanecruising_plugin:
+      ros__parameters:
+        default_downsample_ratio: 18
+        turn_downsample_ratio: 20
+        minimum_speed:  2.2352
 
-# # System controller doesn't have a namespace like others
-# system_controller:
-#   ros__parameters:
-#     signal_configure_delay: 15.0
-#     service_timeout_ms: 500
-#     call_timeout_ms: 10000
+# System controller doesn't have a namespace like others
+system_controller:
+  ros__parameters:
+    signal_configure_delay: 10.0
+    service_timeout_ms: 500
+    call_timeout_ms: 10000

--- a/ford_fusion_sehybrid_2019/GlobalParamsOverride.yaml
+++ b/ford_fusion_sehybrid_2019/GlobalParamsOverride.yaml
@@ -7,34 +7,33 @@
 # use the default values in the respective package's yaml files
 # NOTE: Be sure to include the node name here, which may not be same as the package name
 # NOTE: SubsystemControllers has its own override file for easier organization
-# localization:
-#   localization_manager:
-#     ros__parameters:
-#       localization_mode: 4
-#       x_offset: 0.0
-#       y_offset: 0.0
+localization:
+  localization_manager:
+    ros__parameters:
+      localization_mode: 5
+      x_offset: 2.8
+      y_offset: -2.1
 
-# # Nested namespace example for guidance and plugins
-# guidance:
-#   plan_delegator:
-#     ros__parameters:
-#       max_traj_generation_reattempt: 50
-#   plugins:
-#     lci_strategic_plugin:
-#       ros__parameters:
-#         min_approach_distance: 20.0
-#         trajectory_smoothing_activation_distance: 40.0
-#         minimum_speed: 5.0
-#         algo_minimum_speed: 0.894
-#     inlanecruising_plugin:
-#       ros__parameters:
-#         default_downsample_ratio: 4
-#         turn_downsample_ratio: 4
-#         minimum_speed: 5.0
+# Nested namespace example for guidance and plugins
+guidance:
+  plan_delegator:
+    ros__parameters:
+      max_traj_generation_reattempt: 1000
+  plugins:
+    lci_strategic_plugin:
+      ros__parameters:
+        min_approach_distance: 30.0
+        trajectory_smoothing_activation_distance: 140.0
+        algo_minimum_speed:  4.4704
+    inlanecruising_plugin:
+      ros__parameters:
+        default_downsample_ratio: 18
+        turn_downsample_ratio: 20
+        minimum_speed:  2.2352
 
-# # System controller doesn't have a namespace like others
-# system_controller:
-#   ros__parameters:
-#     signal_configure_delay: 15.0
-#     service_timeout_ms: 500
-#     call_timeout_ms: 10000
+# System controller doesn't have a namespace like others
+system_controller:
+  ros__parameters:
+    signal_configure_delay: 10.0
+    service_timeout_ms: 500
+    call_timeout_ms: 10000

--- a/freightliner_cascadia_2012_dot_10002/GlobalParamsOverride.yaml
+++ b/freightliner_cascadia_2012_dot_10002/GlobalParamsOverride.yaml
@@ -7,34 +7,33 @@
 # use the default values in the respective package's yaml files
 # NOTE: Be sure to include the node name here, which may not be same as the package name
 # NOTE: SubsystemControllers has its own override file for easier organization
-# localization:
-#   localization_manager:
-#     ros__parameters:
-#       localization_mode: 4
-#       x_offset: 0.0
-#       y_offset: 0.0
+localization:
+  localization_manager:
+    ros__parameters:
+      localization_mode: 5
+      x_offset: 2.8
+      y_offset: -2.1
 
-# # Nested namespace example for guidance and plugins
-# guidance:
-#   plan_delegator:
-#     ros__parameters:
-#       max_traj_generation_reattempt: 50
-#   plugins:
-#     lci_strategic_plugin:
-#       ros__parameters:
-#         min_approach_distance: 20.0
-#         trajectory_smoothing_activation_distance: 40.0
-#         minimum_speed: 5.0
-#         algo_minimum_speed: 0.894
-#     inlanecruising_plugin:
-#       ros__parameters:
-#         default_downsample_ratio: 4
-#         turn_downsample_ratio: 4
-#         minimum_speed: 5.0
+# Nested namespace example for guidance and plugins
+guidance:
+  plan_delegator:
+    ros__parameters:
+      max_traj_generation_reattempt: 1000
+  plugins:
+    lci_strategic_plugin:
+      ros__parameters:
+        min_approach_distance: 30.0
+        trajectory_smoothing_activation_distance: 140.0
+        algo_minimum_speed:  4.4704
+    inlanecruising_plugin:
+      ros__parameters:
+        default_downsample_ratio: 18
+        turn_downsample_ratio: 20
+        minimum_speed:  2.2352
 
-# # System controller doesn't have a namespace like others
-# system_controller:
-#   ros__parameters:
-#     signal_configure_delay: 15.0
-#     service_timeout_ms: 500
-#     call_timeout_ms: 10000
+# System controller doesn't have a namespace like others
+system_controller:
+  ros__parameters:
+    signal_configure_delay: 10.0
+    service_timeout_ms: 500
+    call_timeout_ms: 10000

--- a/freightliner_cascadia_2012_dot_10003/GlobalParamsOverride.yaml
+++ b/freightliner_cascadia_2012_dot_10003/GlobalParamsOverride.yaml
@@ -7,34 +7,33 @@
 # use the default values in the respective package's yaml files
 # NOTE: Be sure to include the node name here, which may not be same as the package name
 # NOTE: SubsystemControllers has its own override file for easier organization
-# localization:
-#   localization_manager:
-#     ros__parameters:
-#       localization_mode: 4
-#       x_offset: 0.0
-#       y_offset: 0.0
+localization:
+  localization_manager:
+    ros__parameters:
+      localization_mode: 5
+      x_offset: 2.8
+      y_offset: -2.1
 
-# # Nested namespace example for guidance and plugins
-# guidance:
-#   plan_delegator:
-#     ros__parameters:
-#       max_traj_generation_reattempt: 50
-#   plugins:
-#     lci_strategic_plugin:
-#       ros__parameters:
-#         min_approach_distance: 20.0
-#         trajectory_smoothing_activation_distance: 40.0
-#         minimum_speed: 5.0
-#         algo_minimum_speed: 0.894
-#     inlanecruising_plugin:
-#       ros__parameters:
-#         default_downsample_ratio: 4
-#         turn_downsample_ratio: 4
-#         minimum_speed: 5.0
+# Nested namespace example for guidance and plugins
+guidance:
+  plan_delegator:
+    ros__parameters:
+      max_traj_generation_reattempt: 1000
+  plugins:
+    lci_strategic_plugin:
+      ros__parameters:
+        min_approach_distance: 30.0
+        trajectory_smoothing_activation_distance: 140.0
+        algo_minimum_speed:  4.4704
+    inlanecruising_plugin:
+      ros__parameters:
+        default_downsample_ratio: 18
+        turn_downsample_ratio: 20
+        minimum_speed:  2.2352
 
-# # System controller doesn't have a namespace like others
-# system_controller:
-#   ros__parameters:
-#     signal_configure_delay: 15.0
-#     service_timeout_ms: 500
-#     call_timeout_ms: 10000
+# System controller doesn't have a namespace like others
+system_controller:
+  ros__parameters:
+    signal_configure_delay: 10.0
+    service_timeout_ms: 500
+    call_timeout_ms: 10000

--- a/freightliner_cascadia_2012_dot_10004/GlobalParamsOverride.yaml
+++ b/freightliner_cascadia_2012_dot_10004/GlobalParamsOverride.yaml
@@ -7,34 +7,33 @@
 # use the default values in the respective package's yaml files
 # NOTE: Be sure to include the node name here, which may not be same as the package name
 # NOTE: SubsystemControllers has its own override file for easier organization
-# localization:
-#   localization_manager:
-#     ros__parameters:
-#       localization_mode: 4
-#       x_offset: 0.0
-#       y_offset: 0.0
+localization:
+  localization_manager:
+    ros__parameters:
+      localization_mode: 5
+      x_offset: 2.8
+      y_offset: -2.1
 
-# # Nested namespace example for guidance and plugins
-# guidance:
-#   plan_delegator:
-#     ros__parameters:
-#       max_traj_generation_reattempt: 50
-#   plugins:
-#     lci_strategic_plugin:
-#       ros__parameters:
-#         min_approach_distance: 20.0
-#         trajectory_smoothing_activation_distance: 40.0
-#         minimum_speed: 5.0
-#         algo_minimum_speed: 0.894
-#     inlanecruising_plugin:
-#       ros__parameters:
-#         default_downsample_ratio: 4
-#         turn_downsample_ratio: 4
-#         minimum_speed: 5.0
+# Nested namespace example for guidance and plugins
+guidance:
+  plan_delegator:
+    ros__parameters:
+      max_traj_generation_reattempt: 1000
+  plugins:
+    lci_strategic_plugin:
+      ros__parameters:
+        min_approach_distance: 30.0
+        trajectory_smoothing_activation_distance: 140.0
+        algo_minimum_speed:  4.4704
+    inlanecruising_plugin:
+      ros__parameters:
+        default_downsample_ratio: 18
+        turn_downsample_ratio: 20
+        minimum_speed:  2.2352
 
-# # System controller doesn't have a namespace like others
-# system_controller:
-#   ros__parameters:
-#     signal_configure_delay: 15.0
-#     service_timeout_ms: 500
-#     call_timeout_ms: 10000
+# System controller doesn't have a namespace like others
+system_controller:
+  ros__parameters:
+    signal_configure_delay: 10.0
+    service_timeout_ms: 500
+    call_timeout_ms: 10000

--- a/freightliner_cascadia_2012_dot_80550/GlobalParamsOverride.yaml
+++ b/freightliner_cascadia_2012_dot_80550/GlobalParamsOverride.yaml
@@ -7,34 +7,33 @@
 # use the default values in the respective package's yaml files
 # NOTE: Be sure to include the node name here, which may not be same as the package name
 # NOTE: SubsystemControllers has its own override file for easier organization
-# localization:
-#   localization_manager:
-#     ros__parameters:
-#       localization_mode: 4
-#       x_offset: 0.0
-#       y_offset: 0.0
+localization:
+  localization_manager:
+    ros__parameters:
+      localization_mode: 5
+      x_offset: 2.8
+      y_offset: -2.1
 
-# # Nested namespace example for guidance and plugins
-# guidance:
-#   plan_delegator:
-#     ros__parameters:
-#       max_traj_generation_reattempt: 50
-#   plugins:
-#     lci_strategic_plugin:
-#       ros__parameters:
-#         min_approach_distance: 20.0
-#         trajectory_smoothing_activation_distance: 40.0
-#         minimum_speed: 5.0
-#         algo_minimum_speed: 0.894
-#     inlanecruising_plugin:
-#       ros__parameters:
-#         default_downsample_ratio: 4
-#         turn_downsample_ratio: 4
-#         minimum_speed: 5.0
+# Nested namespace example for guidance and plugins
+guidance:
+  plan_delegator:
+    ros__parameters:
+      max_traj_generation_reattempt: 1000
+  plugins:
+    lci_strategic_plugin:
+      ros__parameters:
+        min_approach_distance: 30.0
+        trajectory_smoothing_activation_distance: 140.0
+        algo_minimum_speed:  4.4704
+    inlanecruising_plugin:
+      ros__parameters:
+        default_downsample_ratio: 18
+        turn_downsample_ratio: 20
+        minimum_speed:  2.2352
 
-# # System controller doesn't have a namespace like others
-# system_controller:
-#   ros__parameters:
-#     signal_configure_delay: 15.0
-#     service_timeout_ms: 500
-#     call_timeout_ms: 10000
+# System controller doesn't have a namespace like others
+system_controller:
+  ros__parameters:
+    signal_configure_delay: 10.0
+    service_timeout_ms: 500
+    call_timeout_ms: 10000

--- a/lexus_rx_450h_2019/GlobalParamsOverride.yaml
+++ b/lexus_rx_450h_2019/GlobalParamsOverride.yaml
@@ -7,34 +7,33 @@
 # use the default values in the respective package's yaml files
 # NOTE: Be sure to include the node name here, which may not be same as the package name
 # NOTE: SubsystemControllers has its own override file for easier organization
-# localization:
-#   localization_manager:
-#     ros__parameters:
-#       localization_mode: 4
-#       x_offset: 0.0
-#       y_offset: 0.0
+localization:
+  localization_manager:
+    ros__parameters:
+      localization_mode: 5
+      x_offset: 2.8
+      y_offset: -2.1
 
-# # Nested namespace example for guidance and plugins
-# guidance:
-#   plan_delegator:
-#     ros__parameters:
-#       max_traj_generation_reattempt: 50
-#   plugins:
-#     lci_strategic_plugin:
-#       ros__parameters:
-#         min_approach_distance: 20.0
-#         trajectory_smoothing_activation_distance: 40.0
-#         minimum_speed: 5.0
-#         algo_minimum_speed: 0.894
-#     inlanecruising_plugin:
-#       ros__parameters:
-#         default_downsample_ratio: 4
-#         turn_downsample_ratio: 4
-#         minimum_speed: 5.0
+# Nested namespace example for guidance and plugins
+guidance:
+  plan_delegator:
+    ros__parameters:
+      max_traj_generation_reattempt: 1000
+  plugins:
+    lci_strategic_plugin:
+      ros__parameters:
+        min_approach_distance: 30.0
+        trajectory_smoothing_activation_distance: 140.0
+        algo_minimum_speed:  4.4704
+    inlanecruising_plugin:
+      ros__parameters:
+        default_downsample_ratio: 18
+        turn_downsample_ratio: 20
+        minimum_speed:  2.2352
 
-# # System controller doesn't have a namespace like others
-# system_controller:
-#   ros__parameters:
-#     signal_configure_delay: 15.0
-#     service_timeout_ms: 500
-#     call_timeout_ms: 10000
+# System controller doesn't have a namespace like others
+system_controller:
+  ros__parameters:
+    signal_configure_delay: 10.0
+    service_timeout_ms: 500
+    call_timeout_ms: 10000


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR adds default values to the global parameters defined in the configs, since platform is crashing without it. Currently default values are taken directly from the corresponding CARMA Platform plugin. 

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.