### PR TITLE
Update to most recent logging paradigm

### DIFF
--- a/basic_simulation_vehicle/carma_rosconsole.conf
+++ b/basic_simulation_vehicle/carma_rosconsole.conf
@@ -3,13 +3,31 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is < my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
 mpc_follower=INFO
 as=WARN
 waypoint_generator=INFO

--- a/basic_simulation_vehicle/carma_rosconsole.conf
+++ b/basic_simulation_vehicle/carma_rosconsole.conf
@@ -1,26 +1,26 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is < my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/basic_simulation_vehicle/carma_rosconsole.conf
+++ b/basic_simulation_vehicle/carma_rosconsole.conf
@@ -28,7 +28,6 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-as=WARN
 route_node=INFO
 carma_wm=INFO
 basic_autonomy=WARN

--- a/basic_simulation_vehicle/carma_rosconsole.conf
+++ b/basic_simulation_vehicle/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/chrysler_pacifica_ehybrid_s_2019/carma_rosconsole.conf
+++ b/chrysler_pacifica_ehybrid_s_2019/carma_rosconsole.conf
@@ -3,13 +3,30 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is < my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/chrysler_pacifica_ehybrid_s_2019/carma_rosconsole.conf
+++ b/chrysler_pacifica_ehybrid_s_2019/carma_rosconsole.conf
@@ -28,7 +28,6 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-as=WARN
 route_node=INFO
 carma_wm=INFO
 basic_autonomy=WARN

--- a/chrysler_pacifica_ehybrid_s_2019/carma_rosconsole.conf
+++ b/chrysler_pacifica_ehybrid_s_2019/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,17 +28,18 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=WARN
 as=WARN
-waypoint_generator=WARN
-route=WARN
-mpc_follower_wrapper=WARN
-carma_wm=WARN
+route_node=INFO
+carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=WARN
+trajectory_executor_node=INFO
 plan_delegator=WARN
-inlanecruising_plugin=WARN
-route_following_plugin=WARN
-pure_pursuit_wrapper=WARN
-system_controller=WARN
-subsystem_controllers=WARN
+inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/chrysler_pacifica_ehybrid_s_2019/carma_rosconsole.conf
+++ b/chrysler_pacifica_ehybrid_s_2019/carma_rosconsole.conf
@@ -1,26 +1,26 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is < my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=WARN
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=WARN
-log4j.logger.ros.route=WARN
-log4j.logger.ros.mpc_follower_wrapper=WARN
-log4j.logger.ros.carma_wm=WARN
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=WARN
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=WARN
-log4j.logger.ros.route_following_plugin=WARN
-log4j.logger.ros.pure_pursuit_wrapper=WARN
-log4j.logger.ros.system_controller=WARN
-log4j.logger.ros.subsystem_controllers=WARN
+mpc_follower=WARN
+as=WARN
+waypoint_generator=WARN
+route=WARN
+mpc_follower_wrapper=WARN
+carma_wm=WARN
+arbitrator=WARN
+trajectory_executor=WARN
+plan_delegator=WARN
+inlanecruising_plugin=WARN
+route_following_plugin=WARN
+pure_pursuit_wrapper=WARN
+system_controller=WARN
+subsystem_controllers=WARN

--- a/chrysler_pacifica_ehybrid_s_2019/carma_rosconsole.conf
+++ b/chrysler_pacifica_ehybrid_s_2019/carma_rosconsole.conf
@@ -27,6 +27,7 @@ roscpp.superdebug=WARN
 #   typo, wrong pluralization) fails silently -- no error is printed.
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/demo_uc2_tim_cp/carma_rosconsole.conf
+++ b/demo_uc2_tim_cp/carma_rosconsole.conf
@@ -3,13 +3,30 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is < my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/demo_uc2_tim_cp/carma_rosconsole.conf
+++ b/demo_uc2_tim_cp/carma_rosconsole.conf
@@ -28,7 +28,6 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-as=WARN
 route_node=INFO
 carma_wm=INFO
 basic_autonomy=WARN

--- a/demo_uc2_tim_cp/carma_rosconsole.conf
+++ b/demo_uc2_tim_cp/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,17 +28,18 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=WARN
 as=WARN
-waypoint_generator=WARN
-route=WARN
-mpc_follower_wrapper=WARN
-carma_wm=WARN
+route_node=INFO
+carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=WARN
+trajectory_executor_node=INFO
 plan_delegator=WARN
-inlanecruising_plugin=WARN
-route_following_plugin=WARN
-pure_pursuit_wrapper=WARN
-system_controller=WARN
-subsystem_controllers=WARN
+inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/demo_uc2_tim_cp/carma_rosconsole.conf
+++ b/demo_uc2_tim_cp/carma_rosconsole.conf
@@ -1,26 +1,26 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is < my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=WARN
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=WARN
-log4j.logger.ros.route=WARN
-log4j.logger.ros.mpc_follower_wrapper=WARN
-log4j.logger.ros.carma_wm=WARN
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=WARN
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=WARN
-log4j.logger.ros.route_following_plugin=WARN
-log4j.logger.ros.pure_pursuit_wrapper=WARN
-log4j.logger.ros.system_controller=WARN
-log4j.logger.ros.subsystem_controllers=WARN
+mpc_follower=WARN
+as=WARN
+waypoint_generator=WARN
+route=WARN
+mpc_follower_wrapper=WARN
+carma_wm=WARN
+arbitrator=WARN
+trajectory_executor=WARN
+plan_delegator=WARN
+inlanecruising_plugin=WARN
+route_following_plugin=WARN
+pure_pursuit_wrapper=WARN
+system_controller=WARN
+subsystem_controllers=WARN

--- a/demo_uc2_tim_cp/carma_rosconsole.conf
+++ b/demo_uc2_tim_cp/carma_rosconsole.conf
@@ -27,6 +27,7 @@ roscpp.superdebug=WARN
 #   typo, wrong pluralization) fails silently -- no error is printed.
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/development/GlobalParamsOverride.yaml
+++ b/development/GlobalParamsOverride.yaml
@@ -7,12 +7,12 @@
 # use the default values in the respective package's yaml files
 # NOTE: Be sure to include the node name here, which may not be same as the package name
 # NOTE: SubsystemControllers has its own override file for easier organization
-# localization:
-#   localization_manager:
-#     ros__parameters:
-#       localization_mode: 4
-#       x_offset: 0.0
-#       y_offset: 0.0
+localization:
+  localization_manager:
+    ros__parameters:
+      localization_mode: 4
+      x_offset: 0.0
+      y_offset: 0.0
 
 # # Nested namespace example for guidance and plugins
 # guidance:

--- a/development/VehicleConfigParams.yaml
+++ b/development/VehicleConfigParams.yaml
@@ -97,7 +97,7 @@ vehicle_participant_type: "vehicle:car"
 
 # Parameter to enable configurable speed limit
 # Value type: Desired
-config_speed_limit: 0.0
+config_speed_limit: 25.0
 
 # Parameters to enable either ROS 1 or ROS 2 (or both) rosbag logging
 use_ros1_rosbag: false

--- a/development/carma_rosconsole.conf
+++ b/development/carma_rosconsole.conf
@@ -3,13 +3,31 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is < my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
 mpc_follower=INFO
 as=WARN
 waypoint_generator=INFO

--- a/development/carma_rosconsole.conf
+++ b/development/carma_rosconsole.conf
@@ -1,26 +1,26 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is < my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=INFO
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=INFO
-log4j.logger.ros.route=INFO
-log4j.logger.ros.mpc_follower_wrapper=INFO
-log4j.logger.ros.carma_wm=INFO
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=INFO
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=INFO
-log4j.logger.ros.route_following_plugin=INFO
-log4j.logger.ros.pure_pursuit_wrapper=INFO
-log4j.logger.ros.system_controller=INFO
-log4j.logger.ros.subsystem_controllers=INFO
+mpc_follower=INFO
+as=WARN
+waypoint_generator=INFO
+route=INFO
+mpc_follower_wrapper=INFO
+carma_wm=INFO
+arbitrator=WARN
+trajectory_executor=INFO
+plan_delegator=WARN
+inlanecruising_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/development/carma_rosconsole.conf
+++ b/development/carma_rosconsole.conf
@@ -28,7 +28,6 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-as=WARN
 route_node=INFO
 carma_wm=INFO
 basic_autonomy=WARN

--- a/development/carma_rosconsole.conf
+++ b/development/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,16 +28,17 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=INFO
 as=WARN
-waypoint_generator=INFO
-route=INFO
-mpc_follower_wrapper=INFO
+route_node=INFO
 carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=INFO
+trajectory_executor_node=INFO
 plan_delegator=WARN
 inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
 route_following_plugin=INFO
 pure_pursuit_wrapper=INFO
 system_controller=INFO

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -18,7 +18,7 @@ version: '2'
 services:
 
   platform:
-    image: usdotfhwastol/carma-platform:latest
+    image: ${DOCKER_ORG}/carma-platform:${DOCKER_TAG}
     network_mode: host
     container_name: platform
     runtime: nvidia
@@ -35,19 +35,6 @@ services:
       - /etc/localtime:/etc/localtime:ro
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/carma_docker.launch.py'
 
-  basic-travel-driver:
-    image: usdotfhwastoldev/carma-platform:basic_travel_simulator
-    network_mode: host
-    volumes_from:
-      - container:carma-config:ro
-    volumes:
-      - /opt/carma/logs:/opt/carma/logs
-      - /opt/carma/.ros:/home/carma/.ros
-      - /opt/carma/data:/opt/carma/data
-    environment:
-      - ROS_IP=127.0.0.1
-    command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch basic_travel_simulator basic_travel_simulator.launch.py'
-
   mock-controller-driver:
     image: ${DOCKER_ORG}/carma-platform:${DOCKER_TAG}
     network_mode: host
@@ -60,35 +47,3 @@ services:
     environment:
       - ROS_IP=127.0.0.1
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/drivers.launch.py drivers:=mock_controller_driver'
-
-  # car-publisher:
-  #   image: local/carma-platform:latest
-  #   network_mode: host
-  #   volumes_from:
-  #     - container:carma-config:ro
-  #   volumes:
-  #     - /opt/carma/logs:/opt/carma/logs
-  #     - /opt/carma/.ros:/home/carma/.ros
-  #     - /opt/carma/data:/opt/carma/data
-  #     - ~/carma_ws/src/carma-platform/trajectory_replayer/config:/opt/carma/install/trajectory_replayer/share/trajectory_replayer/config
-  #   environment:
-  #     - ROS_IP=127.0.0.1
-  #   command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch trajectory_replayer trajectory_replayer_launch.py'
-
-  pedestrian_publisher:
-    image: usdotfhwastoldev/carma-platform:pedestrian-publisher
-    network_mode: host
-    container_name: pedestrian_publisher
-    depends_on:
-      - platform
-    volumes_from:
-      - container:carma-config:ro
-    volumes:
-      - /opt/carma/logs:/opt/carma/logs
-      - /opt/carma/.ros:/home/carma/.ros
-      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
-      - /opt/carma/maps:/opt/carma/maps
-      - /opt/carma/routes:/opt/carma/routes
-      - /etc/timezone:/etc/timezone:ro
-      - /etc/localtime:/etc/localtime:ro
-    command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch pedestrian_publisher pedestrian_publisher_launch.py'

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -18,7 +18,7 @@ version: '2'
 services:
 
   platform:
-    image: ${DOCKER_ORG}/carma-platform:${DOCKER_TAG}
+    image: usdotfhwastol/carma-platform:latest
     network_mode: host
     container_name: platform
     runtime: nvidia
@@ -35,6 +35,19 @@ services:
       - /etc/localtime:/etc/localtime:ro
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/carma_docker.launch.py'
 
+  basic-travel-driver:
+    image: usdotfhwastoldev/carma-platform:basic_travel_simulator
+    network_mode: host
+    volumes_from:
+      - container:carma-config:ro
+    volumes:
+      - /opt/carma/logs:/opt/carma/logs
+      - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/data:/opt/carma/data
+    environment:
+      - ROS_IP=127.0.0.1
+    command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch basic_travel_simulator basic_travel_simulator.launch.py'
+
   mock-controller-driver:
     image: ${DOCKER_ORG}/carma-platform:${DOCKER_TAG}
     network_mode: host
@@ -47,3 +60,35 @@ services:
     environment:
       - ROS_IP=127.0.0.1
     command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch /opt/carma/vehicle/config/drivers.launch.py drivers:=mock_controller_driver'
+
+  # car-publisher:
+  #   image: local/carma-platform:latest
+  #   network_mode: host
+  #   volumes_from:
+  #     - container:carma-config:ro
+  #   volumes:
+  #     - /opt/carma/logs:/opt/carma/logs
+  #     - /opt/carma/.ros:/home/carma/.ros
+  #     - /opt/carma/data:/opt/carma/data
+  #     - ~/carma_ws/src/carma-platform/trajectory_replayer/config:/opt/carma/install/trajectory_replayer/share/trajectory_replayer/config
+  #   environment:
+  #     - ROS_IP=127.0.0.1
+  #   command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch trajectory_replayer trajectory_replayer_launch.py'
+
+  pedestrian_publisher:
+    image: usdotfhwastoldev/carma-platform:pedestrian-publisher
+    network_mode: host
+    container_name: pedestrian_publisher
+    depends_on:
+      - platform
+    volumes_from:
+      - container:carma-config:ro
+    volumes:
+      - /opt/carma/logs:/opt/carma/logs
+      - /opt/carma/.ros:/home/carma/.ros
+      - /opt/carma/vehicle/calibration:/opt/carma/vehicle/calibration
+      - /opt/carma/maps:/opt/carma/maps
+      - /opt/carma/routes:/opt/carma/routes
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    command: bash -c 'source /opt/carma/install/setup.bash && ros2 launch pedestrian_publisher pedestrian_publisher_launch.py'

--- a/ford_fusion_sehybrid_2019/carma_rosconsole.conf
+++ b/ford_fusion_sehybrid_2019/carma_rosconsole.conf
@@ -3,13 +3,30 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is < my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/ford_fusion_sehybrid_2019/carma_rosconsole.conf
+++ b/ford_fusion_sehybrid_2019/carma_rosconsole.conf
@@ -28,7 +28,6 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-as=WARN
 route_node=INFO
 carma_wm=INFO
 basic_autonomy=WARN

--- a/ford_fusion_sehybrid_2019/carma_rosconsole.conf
+++ b/ford_fusion_sehybrid_2019/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,17 +28,18 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=WARN
 as=WARN
-waypoint_generator=WARN
-route=WARN
-mpc_follower_wrapper=WARN
-carma_wm=WARN
+route_node=INFO
+carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=WARN
+trajectory_executor_node=INFO
 plan_delegator=WARN
-inlanecruising_plugin=WARN
-route_following_plugin=WARN
-pure_pursuit_wrapper=WARN
-system_controller=WARN
-subsystem_controllers=WARN
+inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/ford_fusion_sehybrid_2019/carma_rosconsole.conf
+++ b/ford_fusion_sehybrid_2019/carma_rosconsole.conf
@@ -1,26 +1,26 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is < my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=WARN
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=WARN
-log4j.logger.ros.route=WARN
-log4j.logger.ros.mpc_follower_wrapper=WARN
-log4j.logger.ros.carma_wm=WARN
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=WARN
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=WARN
-log4j.logger.ros.route_following_plugin=WARN
-log4j.logger.ros.pure_pursuit_wrapper=WARN
-log4j.logger.ros.system_controller=WARN
-log4j.logger.ros.subsystem_controllers=WARN
+mpc_follower=WARN
+as=WARN
+waypoint_generator=WARN
+route=WARN
+mpc_follower_wrapper=WARN
+carma_wm=WARN
+arbitrator=WARN
+trajectory_executor=WARN
+plan_delegator=WARN
+inlanecruising_plugin=WARN
+route_following_plugin=WARN
+pure_pursuit_wrapper=WARN
+system_controller=WARN
+subsystem_controllers=WARN

--- a/ford_fusion_sehybrid_2019/carma_rosconsole.conf
+++ b/ford_fusion_sehybrid_2019/carma_rosconsole.conf
@@ -27,6 +27,7 @@ roscpp.superdebug=WARN
 #   typo, wrong pluralization) fails silently -- no error is printed.
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/freightliner_cascadia_2012_dot_10002/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10002/carma_rosconsole.conf
@@ -3,13 +3,30 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is < my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/freightliner_cascadia_2012_dot_10002/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10002/carma_rosconsole.conf
@@ -28,7 +28,6 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-as=WARN
 route_node=INFO
 carma_wm=INFO
 basic_autonomy=WARN

--- a/freightliner_cascadia_2012_dot_10002/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10002/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,17 +28,18 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=WARN
 as=WARN
-waypoint_generator=WARN
-route=WARN
-mpc_follower_wrapper=WARN
-carma_wm=WARN
+route_node=INFO
+carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=WARN
+trajectory_executor_node=INFO
 plan_delegator=WARN
-inlanecruising_plugin=WARN
-route_following_plugin=WARN
-pure_pursuit_wrapper=WARN
-system_controller=WARN
-subsystem_controllers=WARN
+inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/freightliner_cascadia_2012_dot_10002/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10002/carma_rosconsole.conf
@@ -1,26 +1,26 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is < my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=WARN
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=WARN
-log4j.logger.ros.route=WARN
-log4j.logger.ros.mpc_follower_wrapper=WARN
-log4j.logger.ros.carma_wm=WARN
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=WARN
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=WARN
-log4j.logger.ros.route_following_plugin=WARN
-log4j.logger.ros.pure_pursuit_wrapper=WARN
-log4j.logger.ros.system_controller=WARN
-log4j.logger.ros.subsystem_controllers=WARN
+mpc_follower=WARN
+as=WARN
+waypoint_generator=WARN
+route=WARN
+mpc_follower_wrapper=WARN
+carma_wm=WARN
+arbitrator=WARN
+trajectory_executor=WARN
+plan_delegator=WARN
+inlanecruising_plugin=WARN
+route_following_plugin=WARN
+pure_pursuit_wrapper=WARN
+system_controller=WARN
+subsystem_controllers=WARN

--- a/freightliner_cascadia_2012_dot_10002/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10002/carma_rosconsole.conf
@@ -27,6 +27,7 @@ roscpp.superdebug=WARN
 #   typo, wrong pluralization) fails silently -- no error is printed.
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/freightliner_cascadia_2012_dot_10003/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10003/carma_rosconsole.conf
@@ -3,13 +3,30 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is < my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/freightliner_cascadia_2012_dot_10003/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10003/carma_rosconsole.conf
@@ -28,7 +28,6 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-as=WARN
 route_node=INFO
 carma_wm=INFO
 basic_autonomy=WARN

--- a/freightliner_cascadia_2012_dot_10003/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10003/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,17 +28,18 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=WARN
 as=WARN
-waypoint_generator=WARN
-route=WARN
-mpc_follower_wrapper=WARN
-carma_wm=WARN
+route_node=INFO
+carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=WARN
+trajectory_executor_node=INFO
 plan_delegator=WARN
-inlanecruising_plugin=WARN
-route_following_plugin=WARN
-pure_pursuit_wrapper=WARN
-system_controller=WARN
-subsystem_controllers=WARN
+inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/freightliner_cascadia_2012_dot_10003/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10003/carma_rosconsole.conf
@@ -1,26 +1,26 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is < my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=WARN
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=WARN
-log4j.logger.ros.route=WARN
-log4j.logger.ros.mpc_follower_wrapper=WARN
-log4j.logger.ros.carma_wm=WARN
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=WARN
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=WARN
-log4j.logger.ros.route_following_plugin=WARN
-log4j.logger.ros.pure_pursuit_wrapper=WARN
-log4j.logger.ros.system_controller=WARN
-log4j.logger.ros.subsystem_controllers=WARN
+mpc_follower=WARN
+as=WARN
+waypoint_generator=WARN
+route=WARN
+mpc_follower_wrapper=WARN
+carma_wm=WARN
+arbitrator=WARN
+trajectory_executor=WARN
+plan_delegator=WARN
+inlanecruising_plugin=WARN
+route_following_plugin=WARN
+pure_pursuit_wrapper=WARN
+system_controller=WARN
+subsystem_controllers=WARN

--- a/freightliner_cascadia_2012_dot_10003/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10003/carma_rosconsole.conf
@@ -27,6 +27,7 @@ roscpp.superdebug=WARN
 #   typo, wrong pluralization) fails silently -- no error is printed.
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/freightliner_cascadia_2012_dot_10004/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10004/carma_rosconsole.conf
@@ -3,13 +3,30 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is < my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/freightliner_cascadia_2012_dot_10004/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10004/carma_rosconsole.conf
@@ -28,7 +28,6 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-as=WARN
 route_node=INFO
 carma_wm=INFO
 basic_autonomy=WARN

--- a/freightliner_cascadia_2012_dot_10004/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10004/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,17 +28,18 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=WARN
 as=WARN
-waypoint_generator=WARN
-route=WARN
-mpc_follower_wrapper=WARN
-carma_wm=WARN
+route_node=INFO
+carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=WARN
+trajectory_executor_node=INFO
 plan_delegator=WARN
-inlanecruising_plugin=WARN
-route_following_plugin=WARN
-pure_pursuit_wrapper=WARN
-system_controller=WARN
-subsystem_controllers=WARN
+inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/freightliner_cascadia_2012_dot_10004/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10004/carma_rosconsole.conf
@@ -1,26 +1,26 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is < my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=WARN
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=WARN
-log4j.logger.ros.route=WARN
-log4j.logger.ros.mpc_follower_wrapper=WARN
-log4j.logger.ros.carma_wm=WARN
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=WARN
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=WARN
-log4j.logger.ros.route_following_plugin=WARN
-log4j.logger.ros.pure_pursuit_wrapper=WARN
-log4j.logger.ros.system_controller=WARN
-log4j.logger.ros.subsystem_controllers=WARN
+mpc_follower=WARN
+as=WARN
+waypoint_generator=WARN
+route=WARN
+mpc_follower_wrapper=WARN
+carma_wm=WARN
+arbitrator=WARN
+trajectory_executor=WARN
+plan_delegator=WARN
+inlanecruising_plugin=WARN
+route_following_plugin=WARN
+pure_pursuit_wrapper=WARN
+system_controller=WARN
+subsystem_controllers=WARN

--- a/freightliner_cascadia_2012_dot_10004/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_10004/carma_rosconsole.conf
@@ -27,6 +27,7 @@ roscpp.superdebug=WARN
 #   typo, wrong pluralization) fails silently -- no error is printed.
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/freightliner_cascadia_2012_dot_80550/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_80550/carma_rosconsole.conf
@@ -3,13 +3,30 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is < my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/freightliner_cascadia_2012_dot_80550/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_80550/carma_rosconsole.conf
@@ -28,7 +28,6 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-as=WARN
 route_node=INFO
 carma_wm=INFO
 basic_autonomy=WARN

--- a/freightliner_cascadia_2012_dot_80550/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_80550/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,17 +28,18 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=WARN
 as=WARN
-waypoint_generator=WARN
-route=WARN
-mpc_follower_wrapper=WARN
-carma_wm=WARN
+route_node=INFO
+carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=WARN
+trajectory_executor_node=INFO
 plan_delegator=WARN
-inlanecruising_plugin=WARN
-route_following_plugin=WARN
-pure_pursuit_wrapper=WARN
-system_controller=WARN
-subsystem_controllers=WARN
+inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/freightliner_cascadia_2012_dot_80550/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_80550/carma_rosconsole.conf
@@ -1,26 +1,26 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is < my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=WARN
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=WARN
-log4j.logger.ros.route=WARN
-log4j.logger.ros.mpc_follower_wrapper=WARN
-log4j.logger.ros.carma_wm=WARN
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=WARN
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=WARN
-log4j.logger.ros.route_following_plugin=WARN
-log4j.logger.ros.pure_pursuit_wrapper=WARN
-log4j.logger.ros.system_controller=WARN
-log4j.logger.ros.subsystem_controllers=WARN
+mpc_follower=WARN
+as=WARN
+waypoint_generator=WARN
+route=WARN
+mpc_follower_wrapper=WARN
+carma_wm=WARN
+arbitrator=WARN
+trajectory_executor=WARN
+plan_delegator=WARN
+inlanecruising_plugin=WARN
+route_following_plugin=WARN
+pure_pursuit_wrapper=WARN
+system_controller=WARN
+subsystem_controllers=WARN

--- a/freightliner_cascadia_2012_dot_80550/carma_rosconsole.conf
+++ b/freightliner_cascadia_2012_dot_80550/carma_rosconsole.conf
@@ -27,6 +27,7 @@ roscpp.superdebug=WARN
 #   typo, wrong pluralization) fails silently -- no error is printed.
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/lexus_rx_450h_2019/carma_rosconsole.conf
+++ b/lexus_rx_450h_2019/carma_rosconsole.conf
@@ -3,13 +3,30 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is < my package name>=< Log level>
+# Syntax is <my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
+#
+# Advanced usage notes:
+# * Both the node name or the dot separated, full namespace name works:
+#   - yield_plugin=DEBUG
+#   - guidance.plugins.yield_plugin=DEBUG
+# * Library loggers also work (which applies to all plugins that link to that library):
+#   - carma_wm=DEBUG
+#   - basic_autonomy=DEBUG
+# * Library loggers can also be scoped to a specific plugin (which applies to only that plugin):
+#   - yield_plugin.carma_wm=DEBUG
+#   ... would only affect the yield_plugin's carma_wm logger, not any other plugin's carma_wm.
+# * A node's own level cascades to its child loggers (yield_plugin=DEBUG also
+#   raises yield_plugin.carma_wm) unless a more specific key overrides it.
+# * A key that doesn't exactly match a real logger name (wrong namespace,
+#   typo, wrong pluralization) fails silently -- no error is printed.
+# * Changes here require restarting the affected process(es) -- levels are
+#   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN

--- a/lexus_rx_450h_2019/carma_rosconsole.conf
+++ b/lexus_rx_450h_2019/carma_rosconsole.conf
@@ -28,7 +28,6 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-as=WARN
 route_node=INFO
 carma_wm=INFO
 basic_autonomy=WARN

--- a/lexus_rx_450h_2019/carma_rosconsole.conf
+++ b/lexus_rx_450h_2019/carma_rosconsole.conf
@@ -3,7 +3,7 @@ ros=WARN
 roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is <my package name>=< Log level>
+# Syntax is <my node name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
@@ -28,17 +28,18 @@ roscpp.superdebug=WARN
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
 
-mpc_follower=WARN
 as=WARN
-waypoint_generator=WARN
-route=WARN
-mpc_follower_wrapper=WARN
-carma_wm=WARN
+route_node=INFO
+carma_wm=INFO
+basic_autonomy=WARN
 arbitrator=WARN
-trajectory_executor=WARN
+trajectory_executor_node=INFO
 plan_delegator=WARN
-inlanecruising_plugin=WARN
-route_following_plugin=WARN
-pure_pursuit_wrapper=WARN
-system_controller=WARN
-subsystem_controllers=WARN
+inlanecruising_plugin=INFO
+cooperative_lanechange=INFO
+lci_strategic_plugin=INFO
+light_controlled_intersection_tactical_plugin=INFO
+route_following_plugin=INFO
+pure_pursuit_wrapper=INFO
+system_controller=INFO
+subsystem_controllers=INFO

--- a/lexus_rx_450h_2019/carma_rosconsole.conf
+++ b/lexus_rx_450h_2019/carma_rosconsole.conf
@@ -1,26 +1,26 @@
 # Set the default ros output level
-log4j.logger.ros=WARN
-log4j.logger.ros.roscpp.superdebug=WARN
+ros=WARN
+roscpp.superdebug=WARN
 
 # Set package specific log level
-# Syntax is log4j.logger.ros.< my package name>=< Log level>
+# Syntax is < my package name>=< Log level>
 # Log levels
 # DEBUG	Detailed logs useful for debugging
 # INFO	Useful logs for understanding system events
 # WARN	Warning notifications that represent problems but will not severly degrade system operation
 # ERROR	Error notifications that severly degrade system operation, but the system might still be able to operate
 # FATAL	Error notification that the system cannot recover from
-log4j.logger.ros.mpc_follower=WARN
-log4j.logger.ros.as=WARN
-log4j.logger.ros.waypoint_generator=WARN
-log4j.logger.ros.route=WARN
-log4j.logger.ros.mpc_follower_wrapper=WARN
-log4j.logger.ros.carma_wm=WARN
-log4j.logger.ros.arbitrator=WARN
-log4j.logger.ros.trajectory_executor=WARN
-log4j.logger.ros.plan_delegator=WARN
-log4j.logger.ros.inlanecruising_plugin=WARN
-log4j.logger.ros.route_following_plugin=WARN
-log4j.logger.ros.pure_pursuit_wrapper=WARN
-log4j.logger.ros.system_controller=WARN
-log4j.logger.ros.subsystem_controllers=WARN
+mpc_follower=WARN
+as=WARN
+waypoint_generator=WARN
+route=WARN
+mpc_follower_wrapper=WARN
+carma_wm=WARN
+arbitrator=WARN
+trajectory_executor=WARN
+plan_delegator=WARN
+inlanecruising_plugin=WARN
+route_following_plugin=WARN
+pure_pursuit_wrapper=WARN
+system_controller=WARN
+subsystem_controllers=WARN

--- a/lexus_rx_450h_2019/carma_rosconsole.conf
+++ b/lexus_rx_450h_2019/carma_rosconsole.conf
@@ -27,6 +27,7 @@ roscpp.superdebug=WARN
 #   typo, wrong pluralization) fails silently -- no error is printed.
 # * Changes here require restarting the affected process(es) -- levels are
 #   read from CARMA_ROS_LOGGING_CONFIG once at startup, no live reload.
+
 mpc_follower=WARN
 as=WARN
 waypoint_generator=WARN


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Supports https://github.com/usdot-fhwa-stol/carma-utils/pull/260
Now the carma-config is using the new paradigm of log level setting
<!--- Describe your changes in detail -->

## Related Issue
See above
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://usdot-carma.atlassian.net/browse/HASS-680
## Motivation and Context
The logging functionality has been long broken for the library code.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.